### PR TITLE
Feat: 블로그 게시물 목록 조회 API

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@ const cors = require("cors");
 
 const indexRouter = require("./routes/indexRoute");
 const keywordRouter = require("./routes/keywordRoute");
+const postRouter = require("./routes/postRoute");
 
 const mongoose = require("mongoose");
 
@@ -33,6 +34,7 @@ app.use(express.static(path.join(__dirname, "public")));
 
 app.use("/", indexRouter);
 app.use("/keyword", keywordRouter);
+app.use("/posts", postRouter);
 
 app.use(function (req, res, next) {
   next(createError(404));

--- a/controllers/keywordController.js
+++ b/controllers/keywordController.js
@@ -1,6 +1,6 @@
 const keywordModel = require("../models/keywordModel");
 const groupModel = require("../models/groupModel");
-const { isValidString, isBlank } = require("../utils/validation");
+const { isValidString, isEmptyString } = require("../utils/validation");
 const { getKeywordPostList } = require("../services/crawling");
 
 const create = async (req, res) => {
@@ -14,7 +14,7 @@ const create = async (req, res) => {
     return res.status(400).send({ message: "[InvalidKeyword] Error occured" });
   }
 
-  if (!isBlank(req.body.groupId)) {
+  if (!isEmptyString(req.body.groupId)) {
     const isNotExistedGroupId = (await groupModel.findOne({ _id: req.body.groupId })) === null;
     if (isNotExistedGroupId) {
       return res.status(400).send({ message: "[NotExistedGroupId] Error occured" });
@@ -36,7 +36,7 @@ const create = async (req, res) => {
     const keywordCreated = await keywordModel.create({ keyword, ownerId });
     const { _id: keywordIdCreated } = keywordCreated;
 
-    if (isBlank(groupId)) {
+    if (isEmptyString(groupId)) {
       const { _id } = await groupModel.create({
         name: groupName,
         ownerId,

--- a/controllers/keywordController.js
+++ b/controllers/keywordController.js
@@ -15,15 +15,15 @@ const create = async (req, res) => {
   }
 
   if (!isBlank(req.body.groupId)) {
-    const isNotExistedGroupId = (await groupModel.find({ _id: req.body.groupId })).length === 0;
+    const isNotExistedGroupId = (await groupModel.findOne({ _id: req.body.groupId })) === null;
     if (isNotExistedGroupId) {
       return res.status(400).send({ message: "[NotExistedGroupId] Error occured" });
     }
   }
 
   const isDuplicatedKeyword =
-    (await keywordModel.find({ groupId: req.body.groupId, keywordList: req.body.keyword }))
-      .length !== 0;
+    (await keywordModel.findOne({ groupId: req.body.groupId, keywordList: req.body.keyword })) ===
+    null;
 
   if (isDuplicatedKeyword) {
     return res.status(400).send({ message: "[ExistedKeyword] Error occured" });

--- a/controllers/postController.js
+++ b/controllers/postController.js
@@ -54,11 +54,22 @@ const find = async (req, res) => {
   const limit = Number(req.query.limit);
   const cursorId = req.query.cursorId;
 
-  const postList = await postModel
-    .find({ keywordId: keywordId })
-    .find({ content: { $regex: `.*${includedKeyword}.*` } })
-    .sort({ createdAt: -1, _id: -1 })
-    .limit(limit);
+  let postList;
+  if (isBlank(cursorId)) {
+    postList = await postModel
+      .find({ keywordId: keywordId })
+      .find({ content: { $regex: `.*${includedKeyword}.*` } })
+      .sort({ _id: -1 })
+      .limit(limit);
+  } else {
+    postList = await postModel
+      .find({ keywordId: keywordId })
+      .find({ content: { $regex: `.*${includedKeyword}.*` } })
+      .find({ _id: { $lt: cursorId } })
+      .sort({ _id: -1 })
+      .limit(limit);
+  }
+
   return res.status(200).json(postList);
 };
 

--- a/controllers/postController.js
+++ b/controllers/postController.js
@@ -1,6 +1,6 @@
 const postModel = require("../models/postModel");
 const keywordModel = require("../models/keywordModel");
-const { isValidString, isValidNumber, isBlank } = require("../utils/validation");
+const { isValidString, isValidNumber, isEmptyString } = require("../utils/validation");
 
 const upsert = async (req) => {
   if (
@@ -31,7 +31,7 @@ const upsert = async (req) => {
 };
 
 const list = async (req, res) => {
-  if (!isValidString(req.params.keywordId) || isBlank(req.params.keywordId)) {
+  if (!isValidString(req.params.keywordId) || isEmptyString(req.params.keywordId)) {
     return res.status(400).send({ message: "[InvalidKeywordId] Error occured" });
   }
   if (!isValidString(req.query.includedKeyword)) {
@@ -49,7 +49,7 @@ const list = async (req, res) => {
     return res.status(400).send({ message: "[NotExistedKeywordId] Error occured" });
   }
 
-  if (!isBlank(req.query.cursorId)) {
+  if (!isEmptyString(req.query.cursorId)) {
     const hasCursorId = (await postModel.findOne({ _id: req.query.cursorId })) !== null;
     if (!hasCursorId) {
       return res.status(400).send({ message: "[NotExistedCursorId] Error occured" });
@@ -63,7 +63,7 @@ const list = async (req, res) => {
   let postListResult;
 
   try {
-    if (isBlank(cursorId)) {
+    if (isEmptyString(cursorId)) {
       postListResult = await postModel
         .find({ keywordId })
         .find({ content: { $regex: includedKeyword } })

--- a/controllers/postController.js
+++ b/controllers/postController.js
@@ -1,5 +1,6 @@
 const postModel = require("../models/postModel");
-const { isValidString, isValidNumber } = require("../utils/validation");
+const keywordModel = require("../models/keywordModel");
+const { isValidString, isValidNumber, isBlank } = require("../utils/validation");
 
 const upsert = async (req) => {
   if (
@@ -29,4 +30,36 @@ const upsert = async (req) => {
   );
 };
 
-module.exports = { upsert };
+const find = async (req, res) => {
+  if (!isValidString(req.params.keywordId) || isBlank(req.params.keywordId)) {
+    return res.status(400).send({ message: "[InvalidKeywordId] Error occured" });
+  }
+  if (!isValidString(req.query.includedKeyword)) {
+    return res.status(400).send({ message: "[InvalidIncludedKeyword] Error occured" });
+  }
+  if (!isValidNumber(Number(req.query.limit)) || Number(req.query.limit) <= 0) {
+    return res.status(400).send({ message: "[InvalidLimit] Error occured" });
+  }
+  if (!isValidString(req.query.cursorId)) {
+    return res.status(400).send({ message: "[InvalidCursorId] Error occured" });
+  }
+
+  const isNotExistKeywordId = (await keywordModel.findOne({ _id: req.params.keywordId })) === null;
+  if (isNotExistKeywordId) {
+    return res.status(400).send({ message: "[InvalidKeywordId] Error occured" });
+  }
+
+  const keywordId = req.params.keywordId;
+  const includedKeyword = req.query.includedKeyword;
+  const limit = Number(req.query.limit);
+  const cursorId = req.query.cursorId;
+
+  const postList = await postModel
+    .find({ keywordId: keywordId })
+    .find({ content: { $regex: `.*${includedKeyword}.*` } })
+    .sort({ createdAt: -1, _id: -1 })
+    .limit(limit);
+  return res.status(200).json(postList);
+};
+
+module.exports = { upsert, find };

--- a/controllers/postController.js
+++ b/controllers/postController.js
@@ -44,9 +44,16 @@ const find = async (req, res) => {
     return res.status(400).send({ message: "[InvalidCursorId] Error occured" });
   }
 
-  const isNotExistKeywordId = (await keywordModel.findOne({ _id: req.params.keywordId })) === null;
-  if (isNotExistKeywordId) {
-    return res.status(400).send({ message: "[InvalidKeywordId] Error occured" });
+  const hasKeywordId = (await keywordModel.findOne({ _id: req.params.keywordId })) !== null;
+  if (!hasKeywordId) {
+    return res.status(400).send({ message: "[NotExistedKeywordId] Error occured" });
+  }
+
+  if (!isBlank(req.query.cursorId)) {
+    const hasCursorId = (await postModel.findOne({ _id: req.query.cursorId })) !== null;
+    if (!hasCursorId) {
+      return res.status(400).send({ message: "[NotExistedCursorId] Error occured" });
+    }
   }
 
   const keywordId = req.params.keywordId;

--- a/controllers/postController.js
+++ b/controllers/postController.js
@@ -65,22 +65,22 @@ const find = async (req, res) => {
   if (isBlank(cursorId)) {
     items = await postModel
       .find({ keywordId: keywordId })
-      .find({ content: { $regex: `.*${includedKeyword}.*` } })
+      .find({ content: { $regex: includedKeyword } })
       .sort({ _id: -1 })
       .limit(limit);
   } else {
     items = await postModel
       .find({ keywordId: keywordId })
-      .find({ content: { $regex: `.*${includedKeyword}.*` } })
+      .find({ content: { $regex: includedKeyword } })
       .find({ _id: { $lt: cursorId } })
       .sort({ _id: -1 })
       .limit(limit);
   }
 
-  const nextCursorId = items[items.length - 1]._id;
+  const nextCursorId = items[items.length - 1]?._id;
   const nextPost = await postModel
     .find({ keywordId: keywordId })
-    .find({ content: { $regex: `.*${includedKeyword}.*` } })
+    .find({ content: { $regex: includedKeyword } })
     .findOne({ _id: { $lt: nextCursorId } });
 
   if (nextPost !== null) {

--- a/controllers/postController.js
+++ b/controllers/postController.js
@@ -65,13 +65,13 @@ const list = async (req, res) => {
   try {
     if (isBlank(cursorId)) {
       postListResult = await postModel
-        .find({ keywordId: keywordId })
+        .find({ keywordId })
         .find({ content: { $regex: includedKeyword } })
         .sort({ _id: -1 })
         .limit(limit);
     } else {
       postListResult = await postModel
-        .find({ keywordId: keywordId })
+        .find({ keywordId })
         .find({ content: { $regex: includedKeyword } })
         .find({ _id: { $lt: cursorId } })
         .sort({ _id: -1 })

--- a/routes/postRoute.js
+++ b/routes/postRoute.js
@@ -2,6 +2,6 @@ const express = require("express");
 const router = express.Router();
 const postController = require("../controllers/postController");
 
-router.get("/:keywordId", postController.find);
+router.get("/:keywordId", postController.list);
 
 module.exports = router;

--- a/routes/postRoute.js
+++ b/routes/postRoute.js
@@ -1,0 +1,7 @@
+const express = require("express");
+const router = express.Router();
+const postController = require("../controllers/postController");
+
+router.get("/:keywordId", postController.find);
+
+module.exports = router;

--- a/utils/validation.js
+++ b/utils/validation.js
@@ -1,5 +1,5 @@
 const isValidString = (string) => {
-  if (string === null || string === undefined || typeof string !== "string") {
+  if (typeof string !== "string") {
     return false;
   }
 
@@ -7,7 +7,7 @@ const isValidString = (string) => {
 };
 
 const isValidNumber = (number) => {
-  if (number === null || number === undefined || typeof number !== "number") {
+  if (typeof number !== "number") {
     return false;
   }
 
@@ -15,7 +15,7 @@ const isValidNumber = (number) => {
 };
 
 const isBlank = (string) => {
-  if (string === "" || string.trim() === "") {
+  if (string.trim() === "") {
     return true;
   }
 

--- a/utils/validation.js
+++ b/utils/validation.js
@@ -14,7 +14,7 @@ const isValidNumber = (number) => {
   return true;
 };
 
-const isBlank = (string) => {
+const isEmptyString = (string) => {
   if (string.trim() === "") {
     return true;
   }
@@ -22,4 +22,4 @@ const isBlank = (string) => {
   return false;
 };
 
-module.exports = { isValidString, isValidNumber, isBlank };
+module.exports = { isValidString, isValidNumber, isEmptyString };


### PR DESCRIPTION
## 이슈

- close #9 

## 상세 설명

- 구독한 키워드에 대한 블로그 게시물을 조회합니다.
- 무한 스크롤 기능을 위해 페이지네이션 기능이 포함되어 있습니다.
- 게시물 목록은 최신순으로 조회됩니다.
- 게시물 본문 내 포함되어 있는 단어를 검색할 수 있습니다.



## PR 체크 사항

- [x] conflict를 모두 해결하였습니다.
- [x] 가장 최신 dev 브랜치를 pull 하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] `console.log`나 주석 여부를 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!

## 리뷰 반영사항

- 유효성 검사 내 중복되는 조건 삭제하였습니다.
- DB 조회시, 하나의 결과값만 가져오는 쿼리에선 `findOne` 쿼리를 사용하는 것으로 통일하였습니다.
- key-value가 동일한 경우에는 shorthand property를 사용하는 것으로 수정했습니다.
- 빈 문자열을 체크하는 유틸 함수명을 isBlank -> isEmptyString 으로 변경했습니다. 

## 리뷰 마감 시간
- 2024년 11월 09일 **오전 10시**까지
