### PR TITLE
Feat: 사용자의 Group List 조회 API 구현 및 대표 키워드 중복 검사 로직 수정

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@ const cors = require("cors");
 
 const indexRouter = require("./routes/indexRoute");
 const userRouter = require("./routes/userRoute");
+const groupsRouter = require("./routes/groupsRoute");
 const keywordRouter = require("./routes/keywordRoute");
 const postRouter = require("./routes/postRoute");
 
@@ -35,6 +36,7 @@ app.use(express.static(path.join(__dirname, "public")));
 
 app.use("/", indexRouter);
 app.use("/user", userRouter);
+app.use("/groups", groupsRouter);
 app.use("/keyword", keywordRouter);
 app.use("/posts", postRouter);
 

--- a/controllers/groupsController.js
+++ b/controllers/groupsController.js
@@ -12,7 +12,7 @@ const list = async (req, res) => {
       .find({ ownerUid: uid })
       .populate("keywordIdList", "keyword");
     res.status(200).json({ groupLength: groupListResult.length, groupListResult });
-  } catch (error) {
+  } catch {
     return res
       .status(500)
       .send({ message: "[ServerError] Error occured in 'groupsController.list'" });

--- a/controllers/groupsController.js
+++ b/controllers/groupsController.js
@@ -1,0 +1,22 @@
+const groupModel = require("../models/groupModel");
+const { isValidString, isEmptyString } = require("../utils/validation");
+
+const list = async (req, res) => {
+  if (!isValidString(req.params.uid) || isEmptyString(req.params.uid)) {
+    return res.status(400).send({ message: "[InvalidUid] Error occured" });
+  }
+
+  try {
+    const { uid } = req.params;
+    const groupListResult = await groupModel
+      .find({ ownerUid: uid })
+      .populate("keywordIdList", "keyword");
+    res.status(200).json({ groupLength: groupListResult.length, groupListResult });
+  } catch (error) {
+    return res
+      .status(500)
+      .send({ message: "[ServerError] Error occured in 'groupsController.list'" });
+  }
+};
+
+module.exports = { list };

--- a/controllers/groupsController.js
+++ b/controllers/groupsController.js
@@ -11,7 +11,7 @@ const list = async (req, res) => {
     const groupListResult = await groupModel
       .find({ ownerUid: uid })
       .populate("keywordIdList", "keyword");
-    res.status(200).json({ groupLength: groupListResult.length, groupListResult });
+    res.status(200).json({ groupListLength: groupListResult.length, groupListResult });
   } catch {
     return res
       .status(500)

--- a/controllers/keywordController.js
+++ b/controllers/keywordController.js
@@ -28,7 +28,7 @@ const create = async (req, res) => {
     .then((query) => {
       return query.keywordIdList.some((doc) => doc.keyword === req.body.keyword);
     })
-    .catch((error) => {
+    .catch(() => {
       return res.status(400).send({ message: "[InvalidGroupId] Error occured" });
     });
 
@@ -64,7 +64,7 @@ const create = async (req, res) => {
       .findOne({ _id: groupId })
       .populate("keywordIdList", "keyword");
     return res.status(201).json(groupResult);
-  } catch (error) {
+  } catch {
     return res
       .status(500)
       .send({ message: "[ServerError] Error occured in 'keywordController.create'" });

--- a/controllers/postController.js
+++ b/controllers/postController.js
@@ -93,7 +93,7 @@ const list = async (req, res) => {
       nextCursorId,
       hasNext,
     });
-  } catch (error) {
+  } catch {
     return res
       .status(500)
       .send({ message: "[ServerError] Error occured in 'postController.list'" });

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -1,4 +1,3 @@
-const keywordModel = require("../models/keywordModel");
 const userModel = require("../models/userModel");
 const { isValidString, isEmptyString } = require("../utils/validation");
 

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -30,7 +30,7 @@ const create = async (req, res) => {
       { upsert: true, new: true }
     );
     return res.status(201).json({ userResult });
-  } catch (error) {
+  } catch {
     return res
       .status(500)
       .send({ message: "[ServerError] Error occured in 'userController.create'" });

--- a/models/groupModel.js
+++ b/models/groupModel.js
@@ -7,7 +7,7 @@ const groupSchema = new Schema(
       type: String,
       required: true,
     },
-    ownerId: {
+    ownerUid: {
       type: String,
       required: true,
     },

--- a/models/keywordModel.js
+++ b/models/keywordModel.js
@@ -7,7 +7,7 @@ const keywordSchema = new Schema(
       type: String,
       required: true,
     },
-    ownerId: {
+    ownerUid: {
       type: String,
       required: true,
     },

--- a/routes/groupsRoute.js
+++ b/routes/groupsRoute.js
@@ -1,0 +1,7 @@
+const express = require("express");
+const router = express.Router();
+const groupsController = require("../controllers/groupsController");
+
+router.get("/:uid", groupsController.list);
+
+module.exports = router;


### PR DESCRIPTION
## 이슈

- close #10 

## 상세 설명

> `uid`로 서버에 `group` 정보 요청 > validation > 해당 `uid`로 `group` collection 조회 > response로 `group` 정보 전달
- 사용자가 만든 그룹 목록을 불러오는 기능을 구현했습니다. (`/groups/{uid}`)
- Postman 활용한 테스트로, Client Request에 대해 `group` 정보가 Response로 전달됨을 확인했습니다.
- 그외 아래 내용을 포함하고 있습니다.
   - `keywordController`의 대표 키워드 중복 여부 query 조건과 중복 검사 상세로직을 수정했습니다. [코멘트 바로가기](https://github.com/Team-Bloblow/Bloblow-Server/pull/15/files#r1835308132)
   - `group` 생성자 id를 저장하는 필드를 `ownerId`에서 `ownerUid`로 수정한 내용도 포함하고 있습니다. [관련 논의 슬랙](https://vanillacoding-course.slack.com/archives/C07UXLS8744/p1731065694546949)

## 참고사항

- `group`과 별도 endpoint로, `groups` Route, Controller를 구현했습니다.
- 사용자가 만든 `group`이 없을 경우 response는 아래와 같습니다.
```js
// 해당 ownerUid의 group 정보가 없는 경우
{
   groupLength: 0,
   items: []
}
```
- .env 파일에 DB_USERNAME, DB_PASSWORD를 설정해주세요.
- 별도 라이브러리는 설치하지 않았습니다.

### Server 실행 후 Postman 테스트 방법
```
// 아래 명령어 입력 후 콘솔을 확인해서, 서버 정상 실행 여부를 확인하세요.
npm run dev
```
URL
```
// 아래 uid는 DB에서 확인해주세요
GET
http://localhost:3000/groups/{uid}
```

## PR 체크 사항

- [x] conflict를 모두 해결하였습니다.
- [x] 가장 최신 dev 브랜치를 pull 하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] `console.log`나 주석 여부를 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!

## 리뷰 반영사항

- [x] 사용하지 않는 error 관련 코드 제거
- [x] groupController response 데이터 변수명 수정

## PR 리뷰 마감시간
- 2024년 11월 9일 오후 11시 까지
