### PR TITLE
Fix: 클라이언트에서 새로 그룹 생성 시 InvalidGroupId 에러 나는 문제 해결

### DIFF
--- a/controllers/keywordController.js
+++ b/controllers/keywordController.js
@@ -19,21 +19,21 @@ const create = async (req, res) => {
     if (isNotExistedGroupId) {
       return res.status(400).send({ message: "[NotExistedGroupId] Error occured" });
     }
-  }
 
-  const isDuplicatedKeyword = await groupModel
-    .findOne({ _id: req.body.groupId })
-    .populate("keywordIdList", "keyword")
-    .exec()
-    .then((query) => {
-      return query.keywordIdList.some((doc) => doc.keyword === req.body.keyword);
-    })
-    .catch(() => {
-      return res.status(400).send({ message: "[InvalidGroupId] Error occured" });
-    });
+    const isDuplicatedKeyword = await groupModel
+      .findOne({ _id: req.body.groupId })
+      .populate("keywordIdList", "keyword")
+      .exec()
+      .then((query) => {
+        return query.keywordIdList.some((doc) => doc.keyword === req.body.keyword);
+      })
+      .catch(() => {
+        return res.status(400).send({ message: "[InvalidGroupId] Error occured" });
+      });
 
-  if (isDuplicatedKeyword) {
-    return res.status(400).send({ message: "[ExistedKeyword] Error occured" });
+    if (isDuplicatedKeyword) {
+      return res.status(400).send({ message: "[ExistedKeyword] Error occured" });
+    }
   }
 
   const { groupName, keyword, ownerUid } = req.body;


### PR DESCRIPTION
## 이슈

- close #2 

## 상세 설명

- 클라이언트에서 새로운 그룹 생성하여 키워드 생성 시 `[InvalidGroupId] Error occured` 에러가 발생했습니다. 이에 중복검사 로직을 groupId가 빈문자열이 아닐 때 실행하는 로직 안으로 옮겼습니다.
![image](https://github.com/user-attachments/assets/2f26f4a7-46ea-4234-ac63-f020288bdbeb)
![image](https://github.com/user-attachments/assets/775b3a1e-4480-4939-b4e3-7ef81a85890a)


## 참고사항

- 우리 모두 여러 가지 엣지 케이스 체크가 필요할 것 같습니다 !

## PR 체크 사항

- [x] conflict를 모두 해결하였습니다.
- [x] 가장 최신 dev 브랜치를 pull 하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] `console.log`나 주석 여부를 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!

## 리뷰 반영사항

-

## PR 리뷰 마감시간

- 2024년 11월 10일 오전 10시까지