### PR TITLE
Feat: 키워드 추가 및 제외 키워드 편집 API (Closed 사유: 기획 수정 24.11.12 )

### DIFF
--- a/controllers/keywordsController.js
+++ b/controllers/keywordsController.js
@@ -1,4 +1,4 @@
-const { isValidString, isEmptyString } = require("../utils/validation");
+const { isValidString, isEmptyString, isValidArray } = require("../utils/validation");
 const keywordModel = require("../models/keywordModel");
 const postModel = require("../models/postModel");
 
@@ -51,7 +51,9 @@ const put = async (req, res) => {
     const keywordResult = await keywordModel
       .findByIdAndUpdate(keywordId, { $set: { includedKeyword, excludedKeyword } }, { new: true })
       .exec();
-    res.status(200).json(keywordResult);
+    const postList = await postModel.find({ keywordId }).exec();
+    const postIdList = postList.length === 0 ? [] : postList.map((data) => data._id);
+    res.status(200).json({ ...keywordResult.toObject(), postId: postIdList });
   } catch {
     res.status(500).send({ message: "[ServerError] Error occured in 'keywordsController.put'" });
   }

--- a/controllers/keywordsController.js
+++ b/controllers/keywordsController.js
@@ -22,4 +22,17 @@ const list = async (req, res) => {
   }
 };
 
-module.exports = { list };
+const put = async (req, res) => {
+  try {
+    const { keywordId } = req.params;
+    const { includedKeyword, excludedKeyword } = req.body;
+    const keywordResult = await keywordModel
+      .findByIdAndUpdate(keywordId, { $set: { includedKeyword, excludedKeyword } }, { new: true })
+      .exec();
+    res.status(200).json(keywordResult);
+  } catch {
+    res.status(500).send({ message: "[ServerError] Error occured in 'keywordsController.put'" });
+  }
+};
+
+module.exports = { list, put };

--- a/controllers/keywordsController.js
+++ b/controllers/keywordsController.js
@@ -23,6 +23,28 @@ const list = async (req, res) => {
 };
 
 const put = async (req, res) => {
+  if (!isValidString(req.params.keywordId) || isEmptyString(req.params.keywordId)) {
+    return res.status(400).send({ message: "[InvalidKeywordId] Error occured" });
+  }
+
+  if (
+    !isValidArray(req.body.includedKeyword) ||
+    !req.body.includedKeyword.every((el) => isValidString(el))
+  ) {
+    return res.status(400).send({ message: "[InvalidIncludedKeyword] Error occured" });
+  }
+
+  if (
+    !isValidArray(req.body.excludedKeyword) ||
+    !req.body.excludedKeyword.every((el) => isValidString(el))
+  ) {
+    return res.status(400).send({ message: "[InvalidExcludedKeyword] Error occured" });
+  }
+
+  if (!isValidString(req.body.ownerUid) || isEmptyString(req.body.ownerUid)) {
+    return res.status(400).send({ message: "[InvalidOwnerUid] Error occured" });
+  }
+
   try {
     const { keywordId } = req.params;
     const { includedKeyword, excludedKeyword } = req.body;

--- a/routes/keywordsRoute.js
+++ b/routes/keywordsRoute.js
@@ -3,5 +3,6 @@ const router = express.Router();
 const keywordsController = require("../controllers/keywordsController");
 
 router.get("/:keywordId", keywordsController.list);
+router.put("/:keywordId", keywordsController.put);
 
 module.exports = router;

--- a/utils/validation.js
+++ b/utils/validation.js
@@ -22,4 +22,12 @@ const isEmptyString = (string) => {
   return false;
 };
 
-module.exports = { isValidString, isValidNumber, isEmptyString };
+const isValidArray = (array) => {
+  if (Array.isArray(array)) {
+    return true;
+  }
+
+  return false;
+};
+
+module.exports = { isValidString, isValidNumber, isEmptyString, isValidArray };


### PR DESCRIPTION
## 이슈

- close #23 
- [API 명세] 추가, 제외 키워드 편집 [링크](https://www.notion.so/13154df96043808196b4fcc2678ad2cf)

## 상세 설명

- 추가/제외 키워드 편집 API를 구현했습니다. (`/keywords/{keywordId}`)
- Postman 활용한 테스트로, Client Request에 대해 `post` 정보가 Response로 전달됨을 확인했습니다.

## 참고사항

- 제외 키워드 `excludeedKeyword`를 포함한 게시물을 필터링 하는 기능을 위주로 리뷰해 주시면 감사하겠습니다. [링크]()
   - `excludeedKeyword`는 array 타입으로 제외 키워드가 1개라도 포함한 게시물은 client에 전달하는 response에서 제외합니다.
- validation 중 동일 대표 키워드 내 추가/제외 키워드 중복 불가 처리는 client에서 대응하여 이번 스펙에서는 제외했습니다.
   - 추후 백엔드에서도 대응이 필요할 경우 반영하겠습니다.
- .env 파일에 아래 값을 설정해주세요.
   - `DB_USERNAME`, `DB_PASSWORD`, `CLIENT_SERVER_URL`, `NAVER_CLIENT_ID`, `NAVER_CLIENT_SECRET`
- 별도 라이브러리는 설치하지 않았습니다.

### Server 실행 후 Postman 테스트 방법
```
// 아래 명령어 입력 후 콘솔을 확인해서, 서버 정상 실행 여부를 확인하세요.
npm run dev
```
```
// 아래 keywordId는 DB에서 확인해주세요
PUT
http://localhost:3000/keywords/{keywordId}
```

## PR 체크 사항

- [x] conflict를 모두 해결하였습니다.
- [x] 가장 최신 dev 브랜치를 pull 하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] `console.log`나 주석 여부를 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!

## 리뷰 반영사항

-
## PR 리뷰 마감 시간
- 2024년 11월 12일 오후 13시 까지