### PR TITLE
Feat: 키워드 대시보드 내 오늘의 게시물 수, 주간 게시물 수 조회 API

### DIFF
--- a/config/constants.js
+++ b/config/constants.js
@@ -1,7 +1,9 @@
 const POST_COUNT = 15;
 const NAVER_BLOG_HOST_NAME = "blog.naver.com";
+const DAY_OF_WEEK = 7;
 
 module.exports = {
   POST_COUNT,
   NAVER_BLOG_HOST_NAME,
+  DAY_OF_WEEK,
 };

--- a/controllers/postController.js
+++ b/controllers/postController.js
@@ -128,7 +128,6 @@ const today = async (req, res) => {
       })
       .countDocuments()
       .exec();
-
     const yesterdayPostCount = await postModel
       .find({ keywordId })
       .find({
@@ -140,16 +139,9 @@ const today = async (req, res) => {
       .countDocuments()
       .exec();
 
-    const diffPostCount = todayPostCount - yesterdayPostCount;
-    const diffPercent =
-      Math.min(todayPostCount, yesterdayPostCount) > 0
-        ? Math.abs(diffPostCount) / todayPostCount
-        : 0;
-
     return res.status(200).json({
       todayPostCount,
-      diffPostCount,
-      diffPercent,
+      diffPostCount: todayPostCount - yesterdayPostCount,
     });
   } catch {
     return res
@@ -163,8 +155,8 @@ const postCount = async (req, res) => {
     return res.status(400).send({ message: "[InvalidKeywordId] Error occured" });
   }
 
-  const hasKeywordId = (await keywordModel.findOne({ _id: req.params.keywordId }).exec()) !== null;
-  if (!hasKeywordId) {
+  const keywordInfo = await keywordModel.findOne({ _id: req.params.keywordId }).exec();
+  if (keywordInfo === null) {
     return res.status(400).send({ message: "[NotExistedKeywordId] Error occured" });
   }
 
@@ -249,6 +241,7 @@ const postCount = async (req, res) => {
 
     return res.status(200).json({
       keywordId,
+      keyword: keywordInfo.keyword,
       dates,
       postCountList,
       cursorId,

--- a/controllers/postController.js
+++ b/controllers/postController.js
@@ -107,8 +107,8 @@ const today = async (req, res) => {
     return res.status(400).send({ message: "[InvalidKeywordId] Error occured" });
   }
 
-  const hasKeywordId = (await keywordModel.findOne({ _id: req.params.keywordId }).exec()) !== null;
-  if (!hasKeywordId) {
+  const keywordInfo = await keywordModel.findOne({ _id: req.params.keywordId }).exec();
+  if (keywordInfo === null) {
     return res.status(400).send({ message: "[NotExistedKeywordId] Error occured" });
   }
 
@@ -140,8 +140,10 @@ const today = async (req, res) => {
       .exec();
 
     return res.status(200).json({
+      id: keywordId,
+      keyword: keywordInfo.keyword,
       todayPostCount,
-      diffPostCount: todayPostCount - yesterdayPostCount,
+      diffPostCount: (todayPostCount - yesterdayPostCount).toString(),
     });
   } catch {
     return res

--- a/controllers/postController.js
+++ b/controllers/postController.js
@@ -122,8 +122,8 @@ const today = async (req, res) => {
       .find({ keywordId })
       .find({
         createdAt: {
-          $gte: today.setHours(0, 0, 0, 0),
-          $lt: today.setHours(23, 59, 59, 999),
+          $gte: new Date().setHours(0, 0, 0, 0),
+          $lt: new Date().setHours(23, 59, 59, 999),
         },
       })
       .countDocuments()
@@ -132,8 +132,8 @@ const today = async (req, res) => {
       .find({ keywordId })
       .find({
         createdAt: {
-          $gte: yesterday.setHours(0, 0, 0, 0),
-          $lt: yesterday.setHours(23, 59, 59, 999),
+          $gte: new Date(yesterday).setHours(0, 0, 0, 0),
+          $lt: new Date(yesterday).setHours(23, 59, 59, 999),
         },
       })
       .countDocuments()

--- a/controllers/postController.js
+++ b/controllers/postController.js
@@ -218,7 +218,7 @@ const postCount = async (req, res) => {
       }
     }
 
-    result.sort((a, b) => a.date - b.date);
+    result.sort((a, b) => new Date(a.date) - new Date(b.date));
     const dates = result.map((item) => item.date);
     const postCountList = result.map((item) => item.postCount);
 

--- a/controllers/postController.js
+++ b/controllers/postController.js
@@ -166,11 +166,15 @@ const postCount = async (req, res) => {
 
   let cursorId;
   if (isValidString(req.query.cursorId)) {
-    cursorId = req.query.cursorId;
+    if (isEmptyString(req.query.cursorId)) {
+      cursorId = new Date();
+      cursorId.setHours(0, 0, 0, 0);
+      cursorId.setDate(cursorId.getDate() - cursorId.getDay());
+    } else {
+      cursorId = req.query.cursorId;
+    }
   } else {
-    cursorId = new Date();
-    cursorId.setHours(0, 0, 0, 0);
-    cursorId.setDate(cursorId.getDate() - cursorId.getDay());
+    return res.status(400).send({ message: "[InvalidCursorId] Error occured" });
   }
 
   try {

--- a/routes/postRoute.js
+++ b/routes/postRoute.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const postController = require("../controllers/postController");
 
 router.get("/:keywordId/today", postController.today);
+router.get("/:keywordId/postCount", postController.postCount);
 router.get("/:keywordId", postController.list);
 
 module.exports = router;

--- a/routes/postRoute.js
+++ b/routes/postRoute.js
@@ -2,6 +2,7 @@ const express = require("express");
 const router = express.Router();
 const postController = require("../controllers/postController");
 
+router.get("/:keywordId/today", postController.today);
 router.get("/:keywordId", postController.list);
 
 module.exports = router;

--- a/utils/date.js
+++ b/utils/date.js
@@ -10,4 +10,16 @@ const isToday = (comparedDate) => {
   return isSameYear && isSameMonth && isSameDate;
 };
 
-module.exports = { isToday };
+const getCursorWeek = (cursorId, day) => {
+  const startDate = new Date(cursorId);
+  startDate.setDate(startDate.getDate() + day);
+  startDate.setHours(0, 0, 0, 0);
+
+  const endDate = new Date(cursorId);
+  endDate.setDate(endDate.getDate() + 6 + day);
+  endDate.setHours(23, 59, 59, 999);
+
+  return [startDate, endDate];
+};
+
+module.exports = { isToday, getCursorWeek };

--- a/utils/date.js
+++ b/utils/date.js
@@ -10,13 +10,13 @@ const isToday = (comparedDate) => {
   return isSameYear && isSameMonth && isSameDate;
 };
 
-const getCursorWeek = (cursorId, day) => {
+const getCursorWeek = (cursorId, addDay) => {
   const startDate = new Date(cursorId);
-  startDate.setDate(startDate.getDate() + day);
+  startDate.setDate(startDate.getDate() + addDay);
   startDate.setHours(0, 0, 0, 0);
 
   const endDate = new Date(cursorId);
-  endDate.setDate(endDate.getDate() + 6 + day);
+  endDate.setDate(endDate.getDate() + 6 + addDay);
   endDate.setHours(23, 59, 59, 999);
 
   return [startDate, endDate];


### PR DESCRIPTION
## 이슈

- close #27 

## 상세 설명

### 오늘의 게시물 수
- 오늘자로 특정 키워드가 언급된 게시물 수를 조회합니다.
- 어제자로 특정 키워드가 언급된 게시물 수를 조회합니다.

### 주간 게시물 수 
- 주간은 일요일부터 토요일까지를 의미합니다.
- cursorId가 없다면, 오늘이 포함되는 주간의 일요일이 cursorId가 됩니다.
- 페이지네이션을 위해 지난주, 다음주의 차트 조회 가능 여부를 전달합니다.
- 지난주, 다음주의 기준이 되는 일요일 cursorId 또한 함께 전달합니다.
- cursorId는 UTC시간으로 이루어져있습니다.

## 참고사항
- ~~오늘의 게시물 수에서 증감률 계산시, 오늘 또는 어제자 게시물 수 중 하나라도 0이라면 증감률은 0이 됩니다.~~
  -> 사용자 측면에선 증감률이 직관적이지 않을 것이라고 판단되어 회의를 통해 증감률 계산 로직 삭제했습니다.
- 오늘 게시물 수 API의 response 예시
  ```
  {
      "id": "12345abcde",
      "keyword": "커피",
      "todayPostCount" : "10",
      "diffPostCount": "5"
  }
  ```
- 주간 게시물 수 API의 response 예시
  ```
  {
      "keywordId": "12345abcde"(테스트ID),
      "dates": [
          "2024.11.10",
          "2024.11.11",
          "2024.11.12",
          "2024.11.13",
          "2024.11.14",
          "2024.11.15",
          "2024.11.16"
      ],
      "postCountList": [
          2,
          1,
          0,
          0,
          0,
          0,
          0
      ],
      "cursorId": "2024-11-09T15:00:00.000Z",
      "previousCursorId": "2024-11-02T15:00:00.000Z",
      "nextCursorId": "2024-11-16T15:00:00.000Z",
      "hasPrevious": true,
      "hasNext": false
  }
  ```

## PR 체크 사항

- [x] conflict를 모두 해결하였습니다.
- [x] 가장 최신 dev 브랜치를 pull 하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] `console.log`나 주석 여부를 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!

## 리뷰 반영사항

- API 명세서에 맞게 response 구조 수정하였습니다.
- new Date()를 통해 어제, 오늘자 날짜 계산하도록 수정하였습니다.
- cursorId 확인시, 빈 문자열 여부 확인하는 로직 추가하였습니다.


## 리뷰 마감 시간
2024년 11월 13일 0시