### PR TITLE
Fix: 키워드 대시보드의 차트 API 주소 수정 및 cursorId을 토요일로 설정 변경

### DIFF
--- a/routes/postRoute.js
+++ b/routes/postRoute.js
@@ -2,8 +2,8 @@ const express = require("express");
 const router = express.Router();
 const postController = require("../controllers/postController");
 
-router.get("/:keywordId/today", postController.today);
-router.get("/:keywordId/postCount", postController.postCount);
+router.get("/keywords/:keywordId/today", postController.today);
+router.get("/keywords/:keywordId/postCount", postController.postCount);
 router.get("/:keywordId", postController.list);
 
 module.exports = router;

--- a/utils/date.js
+++ b/utils/date.js
@@ -10,13 +10,13 @@ const isToday = (comparedDate) => {
   return isSameYear && isSameMonth && isSameDate;
 };
 
-const getCursorWeek = (cursorId, addDay) => {
+const getCursorWeek = (cursorId, addDay = 0) => {
   const startDate = new Date(cursorId);
-  startDate.setDate(startDate.getDate() + addDay);
+  startDate.setDate(startDate.getDate() + 1 + addDay);
   startDate.setHours(0, 0, 0, 0);
 
   const endDate = new Date(cursorId);
-  endDate.setDate(endDate.getDate() + 6 + addDay);
+  endDate.setDate(endDate.getDate() + 7 + addDay);
   endDate.setHours(23, 59, 59, 999);
 
   return [startDate, endDate];


### PR DESCRIPTION
## 이슈

- close #27 

## 상세 설명

- 키워드 대시보트 내 차트 API의 주소에 `/keywords`를 추가했습니다.
- 차트 조회의 기준이 되는 cursorId를 일요일에서 토요일이 되도록 수정했습니다.

## 참고사항

- 주간의 기준은 그대로 일요일에서 토요일까지입니다.

## PR 체크 사항

- [x] conflict를 모두 해결하였습니다.
- [x] 가장 최신 dev 브랜치를 pull 하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] `console.log`나 주석 여부를 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!


