### PR TITLE
Feat: 키워드 대시보드 내 좋아요 수, 댓글 수 차트 조회 API

### DIFF
--- a/controllers/postController.js
+++ b/controllers/postController.js
@@ -244,10 +244,7 @@ const postCount = async (req, res) => {
       (await postModel
         .find({ keywordId })
         .find({
-          $and: [
-            { createdAt: { $gte: previousStartDate } },
-            { createdAt: { $lt: previousEndDate } },
-          ],
+          $and: [{ createdAt: { $lte: previousEndDate } }],
         })
         .countDocuments()
         .exec()) > 0;
@@ -255,7 +252,7 @@ const postCount = async (req, res) => {
       (await postModel
         .find({ keywordId })
         .find({
-          $and: [{ createdAt: { $gte: nextStartDate } }, { createdAt: { $lt: nextEndDate } }],
+          $and: [{ createdAt: { $gte: nextStartDate } }],
         })
         .countDocuments()
         .exec()) > 0;

--- a/controllers/postController.js
+++ b/controllers/postController.js
@@ -277,4 +277,117 @@ const postCount = async (req, res) => {
   }
 };
 
-module.exports = { upsert, list, today, postCount };
+const postLike = async (req, res) => {
+  if (!isValidString(req.params.keywordId) || isEmptyString(req.params.keywordId)) {
+    return res.status(400).send({ message: "[InvalidKeywordId] Error occured" });
+  }
+
+  const keywordInfo = await keywordModel.findOne({ _id: req.params.keywordId }).exec();
+  if (keywordInfo === null) {
+    return res.status(400).send({ message: "[InvalidKeywordId] Error occured" });
+  }
+
+  let cursorIdDate;
+  if (isValidString(req.query.cursorId)) {
+    if (isEmptyString(req.query.cursorId)) {
+      cursorIdDate = new Date();
+      cursorIdDate.setDate(cursorIdDate.getDate() - 1 - cursorIdDate.getDay());
+      cursorIdDate.setHours(0, 0, 0, 0);
+      cursorIdDate = cursorIdDate.toISOString();
+    } else {
+      cursorIdDate = req.query.cursorId;
+    }
+  } else {
+    return res.status(400).send({ message: "[InvalidCursorId] Error occured" });
+  }
+
+  const keywordId = req.params.keywordId;
+
+  try {
+    const [cursorStartDate, cursorEndDate] = getCursorWeek(cursorIdDate, 0);
+
+    const postLikeResultList = await postModel.aggregate([
+      { $match: { keywordId } },
+      {
+        $match: {
+          $and: [{ createdAt: { $gte: cursorStartDate } }, { createdAt: { $lt: cursorEndDate } }],
+        },
+      },
+      {
+        $group: {
+          _id: { $dateToString: { date: "$createdAt", format: "%Y.%m.%d" } },
+          likeCount: { $sum: "$likeCount" },
+        },
+      },
+      { $sort: { _id: 1 } },
+      { $addFields: { date: "$_id" } },
+      { $project: { _id: 0 } },
+    ]);
+
+    if (postLikeResultList.length < DAY_OF_WEEK) {
+      let index = 0;
+
+      while (index < DAY_OF_WEEK) {
+        const targetDate = new Date(cursorStartDate);
+        targetDate.setDate(targetDate.getDate() + index);
+        const targetDateString = `${targetDate.getFullYear()}.${targetDate.getMonth() + 1}.${targetDate.getDate()}`;
+
+        const hasTargetDate = postLikeResultList
+          .map((item) => item.date)
+          .some((date) => date === targetDateString);
+
+        if (!hasTargetDate) {
+          postLikeResultList.push({
+            likeCount: 0,
+            date: targetDateString,
+          });
+        }
+
+        index += 1;
+      }
+    }
+
+    postLikeResultList.sort((a, b) => new Date(a.date) - new Date(b.date));
+    const dates = postLikeResultList.map((item) => item.date);
+    const postLikeList = postLikeResultList.map((item) => item.likeCount);
+
+    const [previousStartDate, previousEndDate] = getCursorWeek(cursorIdDate, -DAY_OF_WEEK);
+    const [nextStartDate, nextEndDate] = getCursorWeek(cursorIdDate, +DAY_OF_WEEK);
+
+    const previousCursorId = new Date(previousStartDate);
+    previousCursorId.setDate(previousStartDate.getDate() - 1);
+    const nextCursorId = new Date(nextStartDate);
+    nextCursorId.setDate(nextCursorId.getDate() - 1);
+
+    const hasPreviousPosts =
+      (await postModel
+        .find({ keywordId })
+        .find({ createdAt: { $lt: previousStartDate } })
+        .countDocuments()
+        .exec()) > 0;
+    const hasNextPosts =
+      (await postModel
+        .find({ keywordId })
+        .find({ createdAt: { $gt: nextEndDate } })
+        .countDocuments()
+        .exec()) > 0;
+
+    res.status(200).json({
+      keywordId,
+      keyword: keywordInfo.keyword,
+      dates,
+      postLikeList,
+      cursorId: cursorIdDate,
+      previousCursorId,
+      nextCursorId,
+      hasPrevious: hasPreviousPosts,
+      hasNext: hasNextPosts,
+    });
+  } catch {
+    return res
+      .status(500)
+      .send({ message: "[ServerError] Error occured in 'postController.postLike'" });
+  }
+};
+
+module.exports = { upsert, list, today, postCount, postLike };

--- a/controllers/postController.js
+++ b/controllers/postController.js
@@ -175,8 +175,9 @@ const postCount = async (req, res) => {
   if (isValidString(req.query.cursorId)) {
     if (isEmptyString(req.query.cursorId)) {
       cursorIdDate = new Date();
-      cursorIdDate.setHours(0, 0, 0, 0);
       cursorIdDate.setDate(cursorIdDate.getDate() - 1 - cursorIdDate.getDay());
+      cursorIdDate.setHours(0, 0, 0, 0);
+      cursorIdDate = cursorIdDate.toISOString();
     } else {
       cursorIdDate = req.query.cursorId;
     }

--- a/controllers/postController.js
+++ b/controllers/postController.js
@@ -201,7 +201,6 @@ const postCount = async (req, res) => {
           postCount: { $sum: 1 },
         },
       },
-      { $sort: { _id: 1 } },
       { $addFields: { date: "$_id" } },
       { $project: { _id: 0 } },
     ]);
@@ -317,7 +316,6 @@ const postLike = async (req, res) => {
           likeCount: { $sum: "$likeCount" },
         },
       },
-      { $sort: { _id: 1 } },
       { $addFields: { date: "$_id" } },
       { $project: { _id: 0 } },
     ]);
@@ -430,7 +428,6 @@ const postComment = async (req, res) => {
           commentCount: { $sum: "$commentCount" },
         },
       },
-      { $sort: { _id: 1 } },
       { $addFields: { date: "$_id" } },
       { $project: { _id: 0 } },
     ]);

--- a/controllers/postController.js
+++ b/controllers/postController.js
@@ -363,13 +363,13 @@ const postLike = async (req, res) => {
     const hasPreviousPosts =
       (await postModel
         .find({ keywordId })
-        .find({ createdAt: { $lt: previousStartDate } })
+        .find({ createdAt: { $lte: previousEndDate } })
         .countDocuments()
         .exec()) > 0;
     const hasNextPosts =
       (await postModel
         .find({ keywordId })
-        .find({ createdAt: { $gt: nextEndDate } })
+        .find({ createdAt: { $gte: nextStartDate } })
         .countDocuments()
         .exec()) > 0;
 

--- a/controllers/postController.js
+++ b/controllers/postController.js
@@ -391,4 +391,117 @@ const postLike = async (req, res) => {
   }
 };
 
-module.exports = { upsert, list, today, postCount, postLike };
+const postComment = async (req, res) => {
+  if (!isValidString(req.params.keywordId) || isEmptyString(req.params.keywordId)) {
+    return res.status(400).send({ message: "[InvalidKeywordId] Error occured" });
+  }
+
+  const keywordInfo = await keywordModel.findOne({ _id: req.params.keywordId }).exec();
+  if (keywordInfo === null) {
+    return res.status(400).send({ message: "[InvalidKeywordId] Error occured" });
+  }
+
+  let cursorIdDate;
+  if (isValidString(req.query.cursorId)) {
+    if (isEmptyString(req.query.cursorId)) {
+      cursorIdDate = new Date();
+      cursorIdDate.setDate(cursorIdDate.getDate() - 1 - cursorIdDate.getDay());
+      cursorIdDate.setHours(0, 0, 0, 0);
+      cursorIdDate = cursorIdDate.toISOString();
+    } else {
+      cursorIdDate = req.query.cursorId;
+    }
+  } else {
+    return res.status(400).send({ message: "[InvalidCursorId] Error occured" });
+  }
+
+  const keywordId = req.params.keywordId;
+
+  try {
+    const [cursorStartDate, cursorEndDate] = getCursorWeek(cursorIdDate, 0);
+
+    const postCommentResultList = await postModel.aggregate([
+      { $match: { keywordId } },
+      {
+        $match: {
+          $and: [{ createdAt: { $gte: cursorStartDate } }, { createdAt: { $lt: cursorEndDate } }],
+        },
+      },
+      {
+        $group: {
+          _id: { $dateToString: { date: "$createdAt", format: "%Y.%m.%d" } },
+          commentCount: { $sum: "$commentCount" },
+        },
+      },
+      { $sort: { _id: 1 } },
+      { $addFields: { date: "$_id" } },
+      { $project: { _id: 0 } },
+    ]);
+
+    if (postCommentResultList.length < DAY_OF_WEEK) {
+      let index = 0;
+
+      while (index < DAY_OF_WEEK) {
+        const targetDate = new Date(cursorStartDate);
+        targetDate.setDate(targetDate.getDate() + index);
+        const targetDateString = `${targetDate.getFullYear()}.${targetDate.getMonth() + 1}.${targetDate.getDate()}`;
+
+        const hasTargetDate = postCommentResultList
+          .map((item) => item.date)
+          .some((date) => date === targetDateString);
+
+        if (!hasTargetDate) {
+          postCommentResultList.push({
+            commentCount: 0,
+            date: targetDateString,
+          });
+        }
+
+        index += 1;
+      }
+    }
+
+    postCommentResultList.sort((a, b) => new Date(a.date) - new Date(b.date));
+    const dates = postCommentResultList.map((item) => item.date);
+    const postCommentList = postCommentResultList.map((item) => item.commentCount);
+
+    const [previousStartDate, previousEndDate] = getCursorWeek(cursorIdDate, -DAY_OF_WEEK);
+    const [nextStartDate, nextEndDate] = getCursorWeek(cursorIdDate, +DAY_OF_WEEK);
+
+    const previousCursorId = new Date(previousStartDate);
+    previousCursorId.setDate(previousStartDate.getDate() - 1);
+    const nextCursorId = new Date(nextStartDate);
+    nextCursorId.setDate(nextCursorId.getDate() - 1);
+
+    const hasPreviousPosts =
+      (await postModel
+        .find({ keywordId })
+        .find({ createdAt: { $lte: previousEndDate } })
+        .countDocuments()
+        .exec()) > 0;
+    const hasNextPosts =
+      (await postModel
+        .find({ keywordId })
+        .find({ createdAt: { $gte: nextStartDate } })
+        .countDocuments()
+        .exec()) > 0;
+
+    res.status(200).json({
+      keywordId,
+      keyword: keywordInfo.keyword,
+      dates,
+      postCommentList,
+      cursorId: cursorIdDate,
+      previousCursorId,
+      nextCursorId,
+      hasPrevious: hasPreviousPosts,
+      hasNext: hasNextPosts,
+    });
+  } catch {
+    return res
+      .status(500)
+      .send({ message: "[ServerError] Error occured in 'postController.postComment'" });
+  }
+};
+
+module.exports = { upsert, list, today, postCount, postLike, postComment };

--- a/controllers/postController.js
+++ b/controllers/postController.js
@@ -192,12 +192,12 @@ const postCount = async (req, res) => {
       { $match: { keywordId } },
       {
         $match: {
-          $and: [{ createdAt: { $gte: cursorStartDate } }, { createdAt: { $lt: cursorEndDate } }],
+          $and: [{ createdAt: { $gte: cursorStartDate } }, { createdAt: { $lte: cursorEndDate } }],
         },
       },
       {
         $group: {
-          _id: { $dateToString: { date: "$createdAt", format: "%Y.%m.%d" } },
+          _id: { $dateToString: { date: "$createdAt", format: "%Y.%m.%d", timezone: "+09:00" } },
           postCount: { $sum: 1 },
         },
       },
@@ -308,12 +308,12 @@ const postLike = async (req, res) => {
       { $match: { keywordId } },
       {
         $match: {
-          $and: [{ createdAt: { $gte: cursorStartDate } }, { createdAt: { $lt: cursorEndDate } }],
+          $and: [{ createdAt: { $gte: cursorStartDate } }, { createdAt: { $lte: cursorEndDate } }],
         },
       },
       {
         $group: {
-          _id: { $dateToString: { date: "$createdAt", format: "%Y.%m.%d" } },
+          _id: { $dateToString: { date: "$createdAt", format: "%Y.%m.%d", timezone: "+09:00" } },
           likeCount: { $sum: "$likeCount" },
         },
       },
@@ -421,12 +421,12 @@ const postComment = async (req, res) => {
       { $match: { keywordId } },
       {
         $match: {
-          $and: [{ createdAt: { $gte: cursorStartDate } }, { createdAt: { $lt: cursorEndDate } }],
+          $and: [{ createdAt: { $gte: cursorStartDate } }, { createdAt: { $lte: cursorEndDate } }],
         },
       },
       {
         $group: {
-          _id: { $dateToString: { date: "$createdAt", format: "%Y.%m.%d" } },
+          _id: { $dateToString: { date: "$createdAt", format: "%Y.%m.%d", timezone: "+09:00" } },
           commentCount: { $sum: "$commentCount" },
         },
       },

--- a/routes/postRoute.js
+++ b/routes/postRoute.js
@@ -4,6 +4,7 @@ const postController = require("../controllers/postController");
 
 router.get("/keywords/:keywordId/today", postController.today);
 router.get("/keywords/:keywordId/postCount", postController.postCount);
+router.get("/keywords/:keywordId/postLike", postController.postLike);
 router.get("/:keywordId", postController.list);
 
 module.exports = router;

--- a/routes/postRoute.js
+++ b/routes/postRoute.js
@@ -5,6 +5,7 @@ const postController = require("../controllers/postController");
 router.get("/keywords/:keywordId/today", postController.today);
 router.get("/keywords/:keywordId/postCount", postController.postCount);
 router.get("/keywords/:keywordId/postLike", postController.postLike);
+router.get("/keywords/:keywordId/postComment", postController.postComment);
 router.get("/:keywordId", postController.list);
 
 module.exports = router;


### PR DESCRIPTION
## 이슈

- close #34 


## 상세 설명

### 주간 좋아요 수 
- 주간은 일요일부터 토요일까지를 의미합니다.
- cursorId는 마지막으로 전달받은 주의 토요일 날짜입니다.
- 페이지네이션을 위해 지난주, 다음주의 차트 조회 가능 여부를 전달합니다.
- 지난주, 다음주의 기준이 되는 cursorId 또한 함께 전달합니다.
- cursorId는 UTC시간으로 이루어져있습니다.

### 주간 댓글 수
- 주간은 일요일부터 토요일까지를 의미합니다.
- cursorId가 없다면, 오늘이 포함되는 주간의 토요일이 cursorId가 됩니다.
- 페이지네이션을 위해 지난주, 다음주의 차트 조회 가능 여부를 전달합니다.
- 지난주, 다음주의 기준이 되는 cursorId 또한 함께 전달합니다.
- cursorId는 UTC시간으로 이루어져있습니다.


## 참고사항

- 주간 게시물 수 조회 API의 페이지네이션 여부 확인 로직에서 
[cursorId를 기준으로 지난주, 다음주의 게시물 수만 파악하는 로직] ->  [cursorId의 기준되는 주간의 이전 기간과 이후 기간 모두 확인하는 로직] 으로 수정했습니다.
- 주간 게시물 수 조회 API에서 cursorId가 없는 경우, cursorId를 구해지지 않는 이슈가 있어서 수정했습니다.

- 주간 좋아요 수 조회 API의 response 예시
```jsx
{
    "keywordId": "1a2b3c4d5e"(테스트ID),
    "keyword": "주문진 막국수",
    "dates": [
        "2024.11.10",
        "2024.11.11",
        "2024.11.12",
        "2024.11.13",
        "2024.11.14",
        "2024.11.15",
        "2024.11.16"
    ],
    "postLikeList": [
        0,
        6,
        0,
        0,
        0,
        0,
        0
    ],
    "cursorId": "2024-11-08T15:00:00.000Z",
    "previousCursorId": "2024-11-01T15:00:00.000Z",
    "nextCursorId": "2024-11-15T15:00:00.000Z",
    "hasPrevious": false,
    "hasNext": false
}
```
- 주간 댓글 수 조회 API의 response 예시
```jsx
{
    "keywordId": "1a2b3c4d5e"(테스트ID),
    "keyword": "주문진 막국수",
    "dates": [
        "2024.11.10",
        "2024.11.11",
        "2024.11.12",
        "2024.11.13",
        "2024.11.14",
        "2024.11.15",
        "2024.11.16"
    ],
    "postCommentList": [
        0,
        6,
        0,
        0,
        0,
        0,
        0
    ],
    "cursorId": "2024-11-08T15:00:00.000Z",
    "previousCursorId": "2024-11-01T15:00:00.000Z",
    "nextCursorId": "2024-11-15T15:00:00.000Z",
    "hasPrevious": false,
    "hasNext": false
}
```

## PR 체크 사항

- [x] conflict를 모두 해결하였습니다.
- [x] 가장 최신 dev 브랜치를 pull 하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] `console.log`나 주석 여부를 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!
- [x] API 명세서를 확인하였으며 동기화 하였습니다.

## 리뷰 반영사항

- 이중 정렬 로직에 대해 수정하였습니다.

## 리뷰 마감 시간
2024년 11월 14일 자정까지
