### PR TITLE
Feat: 키워드 대시보드 내 차트 API에 대한 기간 설정 파라미터 추가 및 광고 여부, 반응 수 차트 API 추가

### DIFF
--- a/config/constants.js
+++ b/config/constants.js
@@ -1,9 +1,17 @@
 const POST_COUNT = 15;
-const NAVER_BLOG_HOST_NAME = "blog.naver.com";
 const DAY_OF_WEEK = 7;
+const MONTH = 1;
+const NAVER_BLOG_HOST_NAME = "blog.naver.com";
+const PERIOD = Object.freeze({
+  WEEKLY: "weekly",
+  MONTHLY_DAILY: "monthlyDaily",
+  MONTHLY_WEEKLY: "monthlyWeekly",
+});
 
 module.exports = {
   POST_COUNT,
   NAVER_BLOG_HOST_NAME,
   DAY_OF_WEEK,
+  MONTH,
+  PERIOD,
 };

--- a/controllers/postController.js
+++ b/controllers/postController.js
@@ -191,6 +191,8 @@ const postCount = async (req, res) => {
     return res.status(400).send({ message: "[NotExistedKeywordId] Error occured" });
   }
 
+  const period = req.query.period ?? "weekly";
+  /*
   let period;
   if (isValidString(req.query.period)) {
     if (isEmptyString(req.query.period)) {
@@ -201,6 +203,7 @@ const postCount = async (req, res) => {
   } else {
     return res.status(400).send({ message: "[InvalidPeriod] Error occured" });
   }
+  */
 
   let cursorIdDate;
   if (isValidString(req.query.cursorId)) {

--- a/controllers/postController.js
+++ b/controllers/postController.js
@@ -298,6 +298,7 @@ const postCount = async (req, res) => {
     return res.status(200).json({
       keywordId,
       keyword: keywordInfo.keyword,
+      period,
       dates,
       postCountList,
       cursorId: cursorIdDate,
@@ -433,6 +434,7 @@ const reactionCount = async (req, res) => {
     res.status(200).json({
       keywordId,
       keyword: keywordInfo.keyword,
+      period,
       dates,
       items: { likeCountList, commentCountList },
       cursorId: cursorIdDate,

--- a/controllers/postController.js
+++ b/controllers/postController.js
@@ -191,8 +191,6 @@ const postCount = async (req, res) => {
     return res.status(400).send({ message: "[NotExistedKeywordId] Error occured" });
   }
 
-  const period = req.query.period ?? "weekly";
-  /*
   let period;
   if (isValidString(req.query.period)) {
     if (isEmptyString(req.query.period)) {
@@ -203,7 +201,6 @@ const postCount = async (req, res) => {
   } else {
     return res.status(400).send({ message: "[InvalidPeriod] Error occured" });
   }
-  */
 
   let cursorIdDate;
   if (isValidString(req.query.cursorId)) {
@@ -326,8 +323,6 @@ const reactionCount = async (req, res) => {
     return res.status(400).send({ message: "[NotExistedKeywordId] Error occured" });
   }
 
-  const period = req.query.period ?? "weekly";
-  /*
   let period;
   if (isValidString(req.query.period)) {
     if (isEmptyString(req.query.period)) {
@@ -338,7 +333,6 @@ const reactionCount = async (req, res) => {
   } else {
     return res.status(400).send({ message: "[InvalidPeriod] Error occured" });
   }
-  */
 
   let cursorIdDate;
   if (isValidString(req.query.cursorId)) {
@@ -464,8 +458,6 @@ const adCount = async (req, res) => {
     return res.status(400).send({ message: "[NotExistedKeywordId] Error occured" });
   }
 
-  const period = req.query.period ?? "weekly";
-  /*
   let period;
   if (isValidString(req.query.period)) {
     if (isEmptyString(req.query.period)) {
@@ -476,7 +468,6 @@ const adCount = async (req, res) => {
   } else {
     return res.status(400).send({ message: "[InvalidPeriod] Error occured" });
   }
-  */
 
   let cursorIdDate;
   if (isValidString(req.query.cursorId)) {

--- a/controllers/postController.js
+++ b/controllers/postController.js
@@ -152,7 +152,7 @@ const today = async (req, res) => {
       .find({
         createdAt: {
           $gte: new Date().setHours(0, 0, 0, 0),
-          $lt: new Date().setHours(23, 59, 59, 999),
+          $lte: new Date().setHours(23, 59, 59, 999),
         },
       })
       .countDocuments()
@@ -162,7 +162,7 @@ const today = async (req, res) => {
       .find({
         createdAt: {
           $gte: new Date(yesterday).setHours(0, 0, 0, 0),
-          $lt: new Date(yesterday).setHours(23, 59, 59, 999),
+          $lte: new Date(yesterday).setHours(23, 59, 59, 999),
         },
       })
       .countDocuments()

--- a/controllers/postController.js
+++ b/controllers/postController.js
@@ -391,7 +391,7 @@ const reactionCount = async (req, res) => {
       let addedDate = 0;
       let periodUnit = period === PERIOD.MONTHLY_WEEKLY ? 7 : 1;
 
-      while (addedDate < DAY_OF_WEEK) {
+      while (addedDate < periodLength) {
         const targetDateString = getTargetDateString(cursorStartDate, addedDate * periodUnit);
         const hasTargetDate = reactionCountListByPeriod
           .map((item) => item.date)

--- a/routes/postRoute.js
+++ b/routes/postRoute.js
@@ -2,6 +2,7 @@ const express = require("express");
 const router = express.Router();
 const postController = require("../controllers/postController");
 
+router.get("/:keywordId/today", postController.today);
 router.get("/:keywordId", postController.list);
 router.get("/keywords/:keywordId/today", postController.today);
 router.get("/keywords/:keywordId/postCount", postController.postCount);

--- a/routes/postRoute.js
+++ b/routes/postRoute.js
@@ -2,11 +2,10 @@ const express = require("express");
 const router = express.Router();
 const postController = require("../controllers/postController");
 
+router.get("/:keywordId", postController.list);
 router.get("/keywords/:keywordId/today", postController.today);
 router.get("/keywords/:keywordId/postCount", postController.postCount);
-router.get("/keywords/:keywordId/postLike", postController.postLike);
-router.get("/keywords/:keywordId/postComment", postController.postComment);
-router.get("/:keywordId", postController.list);
+router.get("/keywords/:keywordId/reactionCount", postController.reactionCount);
 router.get("/groups/:groupId/postCount", postController.groupPostCount);
 router.get("/groups/:groupId/likeCount", postController.groupLikeCount);
 router.get("/groups/:groupId/commentCount", postController.groupCommentCount);

--- a/routes/postRoute.js
+++ b/routes/postRoute.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const postController = require("../controllers/postController");
 
 router.get("/:keywordId/today", postController.today);
+router.get("/:keywordId/postCount", postController.postCount);
 router.get("/:keywordId", postController.list);
 router.get("/keywords/:keywordId/today", postController.today);
 router.get("/keywords/:keywordId/postCount", postController.postCount);

--- a/routes/postRoute.js
+++ b/routes/postRoute.js
@@ -6,6 +6,7 @@ router.get("/:keywordId", postController.list);
 router.get("/keywords/:keywordId/today", postController.today);
 router.get("/keywords/:keywordId/postCount", postController.postCount);
 router.get("/keywords/:keywordId/reactionCount", postController.reactionCount);
+router.get("/keywords/:keywordId/adCount", postController.adCount);
 router.get("/groups/:groupId/postCount", postController.groupPostCount);
 router.get("/groups/:groupId/likeCount", postController.groupLikeCount);
 router.get("/groups/:groupId/commentCount", postController.groupCommentCount);

--- a/utils/date.js
+++ b/utils/date.js
@@ -22,4 +22,21 @@ const getCursorWeek = (cursorIdDate, addDay = 0) => {
   return [startDate, endDate];
 };
 
-module.exports = { isToday, getCursorWeek };
+const getTargetDateString = (date, addDay = 0) => {
+  const targetDate = new Date(date);
+  targetDate.setDate(targetDate.getDate() + addDay);
+
+  const transformedTargetMonth =
+    (targetDate.getMonth() + 1).toString().length === 1
+      ? (targetDate.getMonth() + 1).toString().padStart(2, "0")
+      : (targetDate.getMonth() + 1).toString();
+
+  const transformedTargetDate =
+    targetDate.getDate().toString().length === 1
+      ? targetDate.getDate().toString().padStart(2, "0")
+      : targetDate.getDate().toString();
+
+  return `${targetDate.getFullYear()}.${transformedTargetMonth}.${transformedTargetDate}`;
+};
+
+module.exports = { isToday, getCursorWeek, getTargetDateString };

--- a/utils/date.js
+++ b/utils/date.js
@@ -21,7 +21,35 @@ const getCursorIdDate = (period) => {
     cursorIdDate.setDate(cursorIdDate.getDate() - cursorIdDate.getDay() - 1);
   } else if (period === PERIOD.MONTHLY_DAILY) {
     cursorIdDate.setDate(1);
+  } else if (period === PERIOD.MONTHLY_WEEKLY) {
+    cursorIdDate.setDate(1);
+    cursorIdDate.setDate(-cursorIdDate.getDay());
   }
+
+  return cursorIdDate;
+};
+
+const getPreviousCursorIdDate = (date, period) => {
+  const cursorIdDate = new Date(date);
+
+  if (period === PERIOD.WEEKLY) {
+    cursorIdDate.setDate(cursorIdDate.getDate() - 8);
+  } else if (period === PERIOD.MONTHLY_DAILY) {
+    cursorIdDate.setMonth(cursorIdDate.getMonth() - 1);
+    cursorIdDate.setDate(0);
+  } else if (period === PERIOD.MONTHLY_WEEKLY) {
+    cursorIdDate.setDate(cursorIdDate.getDate() - 1);
+    cursorIdDate.setDate(1);
+    cursorIdDate.setDate(cursorIdDate.getDate() - cursorIdDate.getDay() - 1);
+  }
+
+  return cursorIdDate;
+};
+
+const getNextCursorIdDate = (date) => {
+  let cursorIdDate = new Date(date);
+  cursorIdDate.setHours(0, 0, 0, 0);
+  cursorIdDate = new Date(cursorIdDate);
 
   return cursorIdDate;
 };
@@ -41,7 +69,7 @@ const getCursorWeek = (cursorIdDate, addDay = 0) => {
 const getCursorPeriod = (cursorIdDate, period, addPeriod = 0) => {
   let startDate = new Date(cursorIdDate);
   let endDate = new Date(cursorIdDate);
-  let dateLength = 0;
+  let periodLength = 0;
 
   switch (period) {
     case PERIOD.WEEKLY:
@@ -53,7 +81,7 @@ const getCursorPeriod = (cursorIdDate, period, addPeriod = 0) => {
       endDate.setHours(23, 59, 59, 999);
       endDate = new Date(endDate);
 
-      dateLength = 7;
+      periodLength = 7;
 
       break;
 
@@ -68,12 +96,40 @@ const getCursorPeriod = (cursorIdDate, period, addPeriod = 0) => {
       endDate.setHours(23, 59, 59, 999);
       endDate = new Date(endDate);
 
-      dateLength = endDate.getDate() - startDate.getDate() + 1;
+      periodLength = endDate.getDate() - startDate.getDate() + 1;
+
+      break;
+
+    case PERIOD.MONTHLY_WEEKLY:
+      if (addPeriod !== 0) {
+        startDate.setDate(startDate.getDate() + (6 - startDate.getDay()));
+        startDate.setMonth(startDate.getMonth() + addPeriod);
+        startDate.setDate(1);
+        if (startDate.getDay() > 0) {
+          startDate.setDate(-startDate.getDay());
+        }
+      } else {
+        startDate.setDate(startDate.getDate() + 1);
+
+        endDate.setDate(startDate.getDate() + 6);
+        endDate.setMonth(endDate.getMonth() + 1);
+        endDate.setDate(0);
+        if (endDate.getDay() < 6) {
+          endDate.setDate(endDate.getDate() + (6 - endDate.getDay()));
+        }
+      }
+
+      endDate.setHours(23, 59, 59, 999);
+      endDate = new Date(endDate);
+
+      periodLength = Math.round(
+        (endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24) / 7
+      );
 
       break;
   }
 
-  return [startDate, endDate, dateLength];
+  return [startDate, endDate, periodLength];
 };
 
 const getTargetDateString = (date, addDay = 0) => {
@@ -93,4 +149,12 @@ const getTargetDateString = (date, addDay = 0) => {
   return `${targetDate.getFullYear()}.${transformedTargetMonth}.${transformedTargetDate}`;
 };
 
-module.exports = { isToday, getCursorIdDate, getCursorWeek, getCursorPeriod, getTargetDateString };
+module.exports = {
+  isToday,
+  getCursorIdDate,
+  getPreviousCursorIdDate,
+  getNextCursorIdDate,
+  getCursorWeek,
+  getCursorPeriod,
+  getTargetDateString,
+};

--- a/utils/date.js
+++ b/utils/date.js
@@ -20,7 +20,7 @@ const getCursorIdDate = (period) => {
   if (period === PERIOD.WEEKLY) {
     cursorIdDate.setDate(cursorIdDate.getDate() - cursorIdDate.getDay() - 1);
   } else if (period === PERIOD.MONTHLY_DAILY) {
-    cursorIdDate.setDate(1);
+    cursorIdDate.setDate(0);
   } else if (period === PERIOD.MONTHLY_WEEKLY) {
     cursorIdDate.setDate(1);
     cursorIdDate.setDate(-cursorIdDate.getDay());
@@ -74,8 +74,6 @@ const getCursorPeriod = (cursorIdDate, period, addPeriod = 0) => {
   switch (period) {
     case PERIOD.WEEKLY:
       startDate.setDate(startDate.getDate() + 1 + addPeriod);
-      startDate.setHours(0, 0, 0, 0);
-      startDate = new Date(startDate);
 
       endDate.setDate(endDate.getDate() + 7 + addPeriod);
       endDate.setHours(23, 59, 59, 999);
@@ -86,12 +84,9 @@ const getCursorPeriod = (cursorIdDate, period, addPeriod = 0) => {
       break;
 
     case PERIOD.MONTHLY_DAILY:
-      startDate.setMonth(startDate.getMonth() + addPeriod);
-      startDate.setDate(1);
-      startDate.setHours(0, 0, 0, 0);
-      startDate = new Date(startDate);
+      startDate.setDate(startDate.getDate() + 1);
 
-      endDate.setMonth(endDate.getMonth() + addPeriod + 1);
+      endDate.setMonth(startDate.getMonth() + addPeriod + 1);
       endDate.setDate(0);
       endDate.setHours(23, 59, 59, 999);
       endDate = new Date(endDate);

--- a/utils/date.js
+++ b/utils/date.js
@@ -1,3 +1,5 @@
+const { PERIOD } = require("../config/constants");
+
 const isToday = (comparedDate) => {
   const today = new Date();
 
@@ -10,6 +12,20 @@ const isToday = (comparedDate) => {
   return isSameYear && isSameMonth && isSameDate;
 };
 
+const getCursorIdDate = (period) => {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const cursorIdDate = new Date(today);
+  if (period === PERIOD.WEEKLY) {
+    cursorIdDate.setDate(cursorIdDate.getDate() - cursorIdDate.getDay() - 1);
+  } else if (period === PERIOD.MONTHLY_DAILY) {
+    cursorIdDate.setDate(1);
+  }
+
+  return cursorIdDate;
+};
+
 const getCursorWeek = (cursorIdDate, addDay = 0) => {
   const startDate = new Date(cursorIdDate);
   startDate.setDate(startDate.getDate() + 1 + addDay);
@@ -20,6 +36,44 @@ const getCursorWeek = (cursorIdDate, addDay = 0) => {
   endDate.setHours(23, 59, 59, 999);
 
   return [startDate, endDate];
+};
+
+const getCursorPeriod = (cursorIdDate, period, addPeriod = 0) => {
+  let startDate = new Date(cursorIdDate);
+  let endDate = new Date(cursorIdDate);
+  let dateLength = 0;
+
+  switch (period) {
+    case PERIOD.WEEKLY:
+      startDate.setDate(startDate.getDate() + 1 + addPeriod);
+      startDate.setHours(0, 0, 0, 0);
+      startDate = new Date(startDate);
+
+      endDate.setDate(endDate.getDate() + 7 + addPeriod);
+      endDate.setHours(23, 59, 59, 999);
+      endDate = new Date(endDate);
+
+      dateLength = 7;
+
+      break;
+
+    case PERIOD.MONTHLY_DAILY:
+      startDate.setMonth(startDate.getMonth() + addPeriod);
+      startDate.setDate(1);
+      startDate.setHours(0, 0, 0, 0);
+      startDate = new Date(startDate);
+
+      endDate.setMonth(endDate.getMonth() + addPeriod + 1);
+      endDate.setDate(0);
+      endDate.setHours(23, 59, 59, 999);
+      endDate = new Date(endDate);
+
+      dateLength = endDate.getDate() - startDate.getDate() + 1;
+
+      break;
+  }
+
+  return [startDate, endDate, dateLength];
 };
 
 const getTargetDateString = (date, addDay = 0) => {
@@ -39,4 +93,4 @@ const getTargetDateString = (date, addDay = 0) => {
   return `${targetDate.getFullYear()}.${transformedTargetMonth}.${transformedTargetDate}`;
 };
 
-module.exports = { isToday, getCursorWeek, getTargetDateString };
+module.exports = { isToday, getCursorIdDate, getCursorWeek, getCursorPeriod, getTargetDateString };


### PR DESCRIPTION
## 이슈

- close #44 
- close #43 


## 상세 설명

### 기간 설정 조건
- 차트별 기간 설정 조건으로 weekly(주간) / monthDaily(월간 일단위) / monthWeekly(월간 주단위), 3가지를 추가했습니다.
- 주간는 일요일부터 토요일까지로 설정했습니다.
- 월간 일단위는 해당 월의 1일부터 마지막 일자까지로 설정했습니다.
- 월간 주단위는 해당 월의 1일이 포함된 주의 일요일부터 해당 월의 마지막 일이 포함된 주의 토요일까지를로 설정했습니다.

### 반응 수 및 광고 여부 차트
- 반응 수는 기존의 공감 수와 댓글 수를 하나로 통합시킨 API입니다.
- 광고 여부는 기간의 총 게시물 수에서 광고 여부를 구분하여 전달합니다.

## 참고사항
- #43 이슈도 함께 수정하였습니다.
- 기존 키워드 대시보드 내 차트 AP에 대한 리팩토링도 함께 진행했습니다.
- 월간 주단위 통계를 위해 `$dateTrunc`를 사용했습니다.
  ```jsx
  $dateTrunc: { // 날짜를 자르는 함수
    date: "$createdAt", // 기준 날짜
    unit: "week", // 단위
    binSize: 1, //단위의 사이즈
    timezone: "+09:00", //시간대
    startOfWeek: "sunday", //주의 시작 요일(unit이 week일때만 사용할 수 있는 옵션)
  },
  ```

## PR 체크 사항

- [x] conflict를 모두 해결하였습니다.
- [x] 가장 최신 dev 브랜치를 pull 하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] `console.log`나 주석 여부를 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!
- [x] `API 명세서`를 확인하였으며 동기화 하였습니다.

## 리뷰 반영사항

- 2024년 11월 18일 14시까지
