### PR TITLE
Feat: 게시물 정렬 및 광고 필터링 기능 구현

### DIFF
--- a/controllers/postController.js
+++ b/controllers/postController.js
@@ -81,8 +81,8 @@ const list = async (req, res) => {
   const limit = Number(req.query.limit);
   let hasNext = false;
 
-  const getSortQuery = (request) => {
-    switch (request) {
+  const getSortQuery = (param) => {
+    switch (param) {
       case "NEWEST":
         return { _id: -1 };
 
@@ -103,8 +103,8 @@ const list = async (req, res) => {
         $not: { $regex: excludedKeywordList },
       };
 
-  const getAdFilter = (request) => {
-    switch (request) {
+  const getAdFilter = (param) => {
+    switch (param) {
       case "":
         return { $or: [{ isAd: true }, { isAd: false }] };
 
@@ -116,8 +116,8 @@ const list = async (req, res) => {
     }
   };
 
-  const getOrderQuery = async (request, cursorId) => {
-    switch (request) {
+  const getOrderQuery = async (param, cursorId) => {
+    switch (param) {
       case "LIKE":
         const { likeCount: likeCountOfCursor } = await postModel.findById({ _id: cursorId }).exec();
         return {


### PR DESCRIPTION
## 이슈

- close #40 #41 
- 참고 Client 이슈 https://github.com/Team-Bloblow/Bloblow-Client/pull/39

## 상세 설명

- 키워드별 게시물 정렬 기능을 구현했습니다.
   - 최신 순: DB `post`의 `_id` 내림차순 정렬
   - 공감 많은 순: DB `post`의 `likeCount` 내림차순 정렬
   - 댓글 많은 순: DB `post`의 `commentCount` 내림차순 정렬
- 기존의 포함/제외 키워드 필터 외에 광고 게시물 여부 필터 기능을 구현했습니다.
   - 광고 포함: DB `post`의 `isAd`가 `true` or `false`인 경우
   - 광고만: DB `post`의 `isAd`가 `true`인 경우
   - 광고 제외: DB `post`의 `isAd`가 `false`인 경우

## 참고사항


- 테스트 가능한 브랜치
   - Client: `feat/post-postListFilter-UI`
   - Server: `feat/post-postListSort`
- BASE_URL 변경이 필요할 수 있습니다. 클라이언트 `constant.js` 파일에서 아래 처럼 설정되어 있는지 확인해 주세요.
```
export const BASE_URL = "http://localhost:3000";
```

## PR 체크 사항

- [x] conflict를 모두 해결하였습니다.
- [x] 가장 최신 dev 브랜치를 pull 하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] `console.log`나 주석 여부를 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!
- [x] `API 명세서`를 확인하였으며 동기화 하였습니다.

## 리뷰 반영사항

-

## 리뷰 마감요청 시간
- 2024년 11월 19일 오후 2시