### PR TITLE
Fix: 그룹 정보 내에서도 삭제하려는 키워드 정보 삭제하는 로직 추가

### DIFF
--- a/controllers/keywordController.js
+++ b/controllers/keywordController.js
@@ -83,9 +83,13 @@ const remove = async (req, res) => {
   }
 
   const keywordId = req.params.keywordId;
+  const { _id: groupId } = await groupModel.findOne({ keywordIdList: { $in: keywordId } }).exec();
 
   try {
     await postModel.deleteMany({ keywordId }).exec();
+    await groupModel
+      .updateOne({ _id: groupId }, { $pullAll: { keywordIdList: [keywordInfo._id] } })
+      .exec();
     await keywordModel.deleteOne({ _id: keywordInfo._id }).exec();
 
     return res.status(200).json({ status: "ok" });


### PR DESCRIPTION
## 이슈

- close #59 


## 상세 설명

- 그룹 정보 내에 해당 그룹에 속하는 키워드 ID 목록에서 삭제하려는 키워드ID가 삭제되지 않아 발생한 이슈입니다.
- 키워드 정보 삭제, 해당 키워드가 언급된 게시물 목록과 더불어 그룹 정보 내에 키워드 ID를 삭제하는 로직을 추가했습니다.

## 참고사항

- 삭제 완료한 후, 그룹 대시보드로 이동하며 정상적으로 차트가 표시됩니다.


## PR 체크 사항

- [ ] conflict를 모두 해결하였습니다.
- [ ] 가장 최신 dev 브랜치를 pull 하였습니다.
- [ ] 코드 컨벤션을 모두 확인하였습니다.
- [ ] `console.log`나 주석 여부를 확인하였습니다.
- [ ] 브랜치명을 확인하였습니다.
- [ ] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!
- [ ] `API 명세서`를 확인하였으며 동기화 하였습니다.

## 리뷰 반영사항

- 2024년 11월 22일 22시까지
