### PR TITLE
Feat: 최근 업데이트 그룹의 키워드별 게시물 수 조회 API 구현

### DIFF
--- a/controllers/groupsController.js
+++ b/controllers/groupsController.js
@@ -28,6 +28,7 @@ const summary = async (req, res) => {
   }
 
   try {
+    const postUpdateNewest = [];
     const { uid } = req.params;
     const keywordListResult = await keywordModel.find({ ownerUid: uid }).exec();
     const keywordIdList = keywordListResult.map((keyword) => keyword._id);
@@ -43,6 +44,36 @@ const summary = async (req, res) => {
 
     const postCreatedNewest = postCreatedLast?.reduce((prev, curr) => {
       return new Date(prev.createdAt) <= new Date(curr.createdAt) ? curr : prev;
+    });
+    const dateNewest = postCreatedNewest.createdAt.toString();
+    const dateNewestStart = new Date(dateNewest).setHours(0, 0, 0, 0);
+    const dateNewestEnd = new Date(dateNewest).setHours(23, 59, 59, 999);
+    const groupListResult = await groupModel
+      .find({ ownerUid: uid })
+      .populate("keywordIdList", "keyword")
+      .exec();
+    const groupUpdatedNewest = groupListResult.filter((group) => {
+      return group.keywordIdList.some(
+        (keyword) => keyword._id.toString() === postCreatedNewest.keywordId.toString()
+      );
+    })[0];
+    const keywordList = groupUpdatedNewest.keywordIdList;
+
+    for await (const keyword of keywordList) {
+      const post = await postModel
+        .find({
+          keywordId: keyword._id,
+          createdAt: { $gte: dateNewestStart, $lte: dateNewestEnd },
+        })
+        .exec();
+
+      postUpdateNewest.push({ name: keyword.keyword, count: post.length });
+    }
+
+    res.status(200).json({
+      group: groupUpdatedNewest.name,
+      postUpdateNewest,
+      lastUpdatedAt: postCreatedNewest.createdAt,
     });
   } catch {
     return res

--- a/controllers/groupsController.js
+++ b/controllers/groupsController.js
@@ -1,4 +1,6 @@
 const groupModel = require("../models/groupModel");
+const keywordModel = require("../models/keywordModel");
+const postModel = require("../models/postModel");
 const { isValidString, isEmptyString } = require("../utils/validation");
 
 const list = async (req, res) => {
@@ -20,4 +22,33 @@ const list = async (req, res) => {
   }
 };
 
-module.exports = { list };
+const summary = async (req, res) => {
+  if (!isValidString(req.params.uid) || isEmptyString(req.params.uid)) {
+    return res.status(400).send({ message: "[InvalidUid] Error occured" });
+  }
+
+  try {
+    const { uid } = req.params;
+    const keywordListResult = await keywordModel.find({ ownerUid: uid }).exec();
+    const keywordIdList = keywordListResult.map((keyword) => keyword._id);
+    const postCreatedLast = [];
+
+    for await (const id of keywordIdList) {
+      const postResult = await postModel.find({ keywordId: id }).sort({ createdAt: -1 }).exec();
+      postCreatedLast.push({
+        keywordId: postResult[0].keywordId,
+        createdAt: postResult[0].createdAt,
+      });
+    }
+
+    const postCreatedNewest = postCreatedLast?.reduce((prev, curr) => {
+      return new Date(prev.createdAt) <= new Date(curr.createdAt) ? curr : prev;
+    });
+  } catch {
+    return res
+      .status(500)
+      .send({ message: "[ServerError] Error occured in 'groupsController.summary'" });
+  }
+};
+
+module.exports = { list, summary };

--- a/routes/groupsRoute.js
+++ b/routes/groupsRoute.js
@@ -3,5 +3,6 @@ const router = express.Router();
 const groupsController = require("../controllers/groupsController");
 
 router.get("/:uid", groupsController.list);
+router.get("/:uid/summary", groupsController.summary);
 
 module.exports = router;


### PR DESCRIPTION
## 이슈

- close #67 

## 상세 설명

- 유저 로그인 시 MyPage에서 최근 업데이트된 그룹의 게시물 수 현황을 조회할 수 있습니다.
     - MyPage 좌측 사이드바의 UI로 표기될 데이터를 제공하는 API 입니다.
- 유저의 가장 마지막 생성된 게시물의 `createdAt`을 기준으로 최근 업데이트 그룹을 판별합니다.
- 이미지 첨부
    <image width="300" src="https://github.com/user-attachments/assets/8d359502-d643-4354-bd5a-37915d5ffa59">

## 참고사항

- 이에 클라이언트 요청에 따라 최근 업데이트 그룹명, 해당 그룹의 키워드별 게시물 수, 최근 업데이트 일자 정보를 응답으로 전달합니다.
- Postman 요청 및 응답 확인으로 테스트 진행 완료했습니다.
- 클라이언트 작업은 이어서 진행 예정입니다.
- 별도 라이브러리는 설치하지 않았습니다.

```
// request
GET /groups/{uid}/summary
Content-Type: application/json
```
```
// response 예시
{
    "group": "[샘플] 카페 메뉴",
    "postUpdateNewest": [
        {
            "name": "꿀아메리카노",
            "count": 1
        },
        {
            "name": "피스타치오 프라페",
            "count": 1
        }
    ],
    "lastUpdatedAt": "2024-12-26T09:19:42.134Z"
}
```

## PR 체크 사항

- [ ] conflict를 모두 해결하였습니다.
- [ ] 가장 최신 dev 브랜치를 pull 하였습니다.
- [ ] 코드 컨벤션을 모두 확인하였습니다.
- [ ] `console.log`나 주석 여부를 확인하였습니다.
- [ ] 브랜치명을 확인하였습니다.
- [ ] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!
- [ ] `API 명세서`를 확인하였으며 동기화 하였습니다.

## 리뷰 반영사항

-
