### PR TITLE
Feat: 신규 사용자에게 샘플 그룹 데이터 추가해주는 로직 추가

### DIFF
--- a/config/constants.js
+++ b/config/constants.js
@@ -7,6 +7,7 @@ const PERIOD = Object.freeze({
   MONTHLY_DAILY: "monthlyDaily",
   MONTHLY_WEEKLY: "monthlyWeekly",
 });
+const SAMPLE_GROUP_ID = "676bacaa98cdcd850d3b9c78";
 
 module.exports = {
   POST_COUNT,
@@ -14,4 +15,5 @@ module.exports = {
   DAY_OF_WEEK,
   MONTH,
   PERIOD,
+  SAMPLE_GROUP_ID,
 };

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -45,7 +45,11 @@ const create = async (req, res) => {
 
         for await (const sampleKeywordId of sampleGroup.keywordIdList) {
           const sampleKeyword = await keywordModel.findById(sampleKeywordId).exec();
-          const samplePostList = await postModel.find({ keywordId: sampleKeywordId }).exec();
+          const samplePostList = await postModel
+            .find({ keywordId: sampleKeywordId })
+            .sort({ createdAt: 1 })
+            .exec();
+
           const [newKeyword] = await keywordModel.create(
             [
               {

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -1,3 +1,7 @@
+const { SAMPLE_GROUP_ID } = require("../config/constants");
+const groupModel = require("../models/groupModel");
+const keywordModel = require("../models/keywordModel");
+const postModel = require("../models/postModel");
 const userModel = require("../models/userModel");
 const { isValidString, isEmptyString } = require("../utils/validation");
 
@@ -18,17 +22,82 @@ const create = async (req, res) => {
   const { uid, email, displayName, photoURL } = req.body;
 
   try {
-    const userResult = await userModel.findOneAndUpdate(
-      { uid },
-      {
-        $setOnInsert: {
-          email,
-          displayName,
-          photoURL,
+    const isUnregisteredUser = (await userModel.exists({ uid }).exec()) === null;
+    const userResult = await userModel
+      .findOneAndUpdate(
+        { uid },
+        {
+          $setOnInsert: {
+            email,
+            displayName,
+            photoURL,
+          },
         },
-      },
-      { upsert: true, new: true }
-    );
+        { upsert: true, new: true }
+      )
+      .exec();
+
+    if (isUnregisteredUser) {
+      const sampleGroup = await groupModel.findById(SAMPLE_GROUP_ID).exec();
+
+      if (sampleGroup.keywordIdList.length > 0) {
+        const newKeywordIdList = [];
+
+        for await (const sampleKeywordId of sampleGroup.keywordIdList) {
+          const sampleKeyword = await keywordModel.findById(sampleKeywordId).exec();
+          const samplePostList = await postModel.find({ keywordId: sampleKeywordId }).exec();
+          const [newKeyword] = await keywordModel.create(
+            [
+              {
+                keyword: sampleKeyword.keyword,
+                ownerUid: userResult.uid,
+                createdAt: sampleKeyword.createdAt,
+                updatedAt: new Date(),
+              },
+            ],
+            { timestamps: false }
+          );
+
+          if (samplePostList.length > 0) {
+            for await (const samplePost of samplePostList) {
+              await postModel.create(
+                [
+                  {
+                    keywordId: newKeyword._id,
+                    title: samplePost.title,
+                    link: samplePost.link,
+                    content: samplePost.content,
+                    description: samplePost.description,
+                    commentCount: samplePost.commentCount,
+                    likeCount: samplePost.likeCount,
+                    isAd: samplePost.isAd,
+                    createdAt: samplePost.createdAt,
+                    updatedAt: new Date(),
+                  },
+                ],
+                { timestamps: false }
+              );
+            }
+          }
+
+          newKeywordIdList.push(newKeyword._id);
+        }
+
+        await groupModel.create(
+          [
+            {
+              ownerUid: userResult.uid,
+              name: sampleGroup.name,
+              keywordIdList: newKeywordIdList,
+              createdAt: sampleGroup.createdAt,
+              updatedAt: new Date(),
+            },
+          ],
+          { timestamps: false }
+        );
+      }
+    }
+
     return res.status(201).json({ userResult });
   } catch {
     return res


### PR DESCRIPTION
## 이슈

- close #69 

## 상세 설명

- 신규 가입한 사용자에 한하여 샘플 그룹 데이터를 추가해주는 로직입니다.
- 샘플 그룹, 키워드, 게시물 모두 해당 사용자의 데이터로 추가됩니다.
- 샘플 그룹 내에 키워드가 1개 이상 등록되어 있는 경우에만 샘플 데이터가 추가됩니다.

## 참고사항
- create()에 옵션 설정을 추가하기 위해선 첫번째 인자가 배열이여야 하므로, 아래와 같이 코드를 작성했습니다. 
[mongoose의 create API](https://mongoosejs.com/docs/api/model.html#Model.create())
```
const [newKeyword] = await keywordModel.create(
  [
    {
      keyword: sampleKeyword.keyword,
      ownerUid: userResult.uid,
      createdAt: sampleKeyword.createdAt,
      updatedAt: new Date(),
    },
  ],
  { timestamps: false }
);
```
- 샘플 데이터 내 키워드에 종속된 게시물도 추가하는 데에 다소 시간이 소요되어, 화면단에서 로그인 창이 닫힌 후 1-2초 정도 후 메인 페이지로 이동하고 있습니다. 해당 부분 클라이언트단에서 스피너 삽입과 같은 추가 작업 예정입니다.

## PR 체크 사항

- [ ] conflict를 모두 해결하였습니다.
- [ ] 가장 최신 dev 브랜치를 pull 하였습니다.
- [ ] 코드 컨벤션을 모두 확인하였습니다.
- [ ] `console.log`나 주석 여부를 확인하였습니다.
- [ ] 브랜치명을 확인하였습니다.
- [ ] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!
- [ ] `API 명세서`를 확인하였으며 동기화 하였습니다.

## 리뷰 반영사항

-
