### PR TITLE
Feat: 기존 그룹 및 키워드 생성하는 API를 각 그룹과 키워드를 생성하는 API로 분리

### DIFF
--- a/controllers/groupController.js
+++ b/controllers/groupController.js
@@ -1,6 +1,36 @@
 const groupModel = require("../models/groupModel");
 const { isValidString, isEmptyString } = require("../utils/validation");
 
+const create = async (req, res) => {
+  if (!isValidString(req.body.groupName) || isEmptyString(req.body.groupName)) {
+    return res.status(400).send({ message: "[InvalidGroupName] Error occured" });
+  }
+  if (!isValidString(req.body.ownerUid) || isEmptyString(req.body.ownerUid)) {
+    return res.status(400).send({ message: "[InvalidOwnerUid] Error occured" });
+  }
+
+  const isDuplicatedGroupName = await groupModel.findOne({
+    ownerUid: req.body.ownerUid,
+    name: req.body.groupName,
+  });
+  if (isDuplicatedGroupName) {
+    return res.status(400).send({ message: "[ExistedGroupName] Error occured" });
+  }
+
+  const { ownerUid, groupName } = req.body;
+
+  try {
+    const { _id: groupIdCreated } = await groupModel.create({ ownerUid, name: groupName });
+    const groupResult = await groupModel.findById(groupIdCreated);
+
+    return res.status(201).json(groupResult);
+  } catch {
+    return res
+      .status(500)
+      .send({ message: "[ServerError] Error occured in 'groupController.create'" });
+  }
+};
+
 const edit = async (req, res) => {
   if (!isValidString(req.params.groupId) || isEmptyString(req.params.groupId)) {
     return res.status(400).send({ message: "[InvalidGroupId] Error occured" });
@@ -35,4 +65,4 @@ const edit = async (req, res) => {
   }
 };
 
-module.exports = { edit };
+module.exports = { create, edit };

--- a/controllers/keywordController.js
+++ b/controllers/keywordController.js
@@ -37,9 +37,7 @@ const create = async (req, res) => {
   const { groupId, ownerUid, keyword } = req.body;
 
   try {
-    const keywordResult = await keywordModel.create({ keyword, ownerUid });
-    const { _id: keywordIdCreated } = keywordResult;
-
+    const { _id: keywordIdCreated } = await keywordModel.create({ keyword, ownerUid });
     const groupResult = await groupModel.findByIdAndUpdate(
       { _id: groupId },
       { $push: { keywordIdList: keywordIdCreated } },

--- a/controllers/keywordController.js
+++ b/controllers/keywordController.js
@@ -2,68 +2,50 @@ const keywordModel = require("../models/keywordModel");
 const groupModel = require("../models/groupModel");
 const postModel = require("../models/postModel");
 const { isValidString, isEmptyString } = require("../utils/validation");
-const { getKeywordPostList } = require("../services/crawling");
 
 const create = async (req, res) => {
-  if (!isValidString(req.body.groupId)) {
+  if (!isValidString(req.body.groupId) || isEmptyString(req.body.groupId)) {
     return res.status(400).send({ message: "[InvalidGroupId] Error occured" });
   }
-  if (!isValidString(req.body.ownerUid)) {
+  if (!isValidString(req.body.ownerUid) || isEmptyString(req.body.ownerUid)) {
     return res.status(400).send({ message: "[InvalidOwnerUid] Error occured" });
   }
-  if (!isValidString(req.body.keyword)) {
+  if (!isValidString(req.body.keyword) || isEmptyString(req.body.keyword)) {
     return res.status(400).send({ message: "[InvalidKeyword] Error occured" });
   }
 
-  if (!isEmptyString(req.body.groupId)) {
-    const isNotExistedGroupId = (await groupModel.findOne({ _id: req.body.groupId })) === null;
-    if (isNotExistedGroupId) {
-      return res.status(400).send({ message: "[NotExistedGroupId] Error occured" });
-    }
-
-    const isDuplicatedKeyword = await groupModel
-      .findOne({ _id: req.body.groupId })
-      .populate("keywordIdList", "keyword")
-      .exec()
-      .then((query) => {
-        return query.keywordIdList.some((doc) => doc.keyword === req.body.keyword);
-      })
-      .catch(() => {
-        return res.status(400).send({ message: "[InvalidGroupId] Error occured" });
-      });
-
-    if (isDuplicatedKeyword) {
-      return res.status(400).send({ message: "[ExistedKeyword] Error occured" });
-    }
+  const isNotExistedGroupId = (await groupModel.findOne({ _id: req.body.groupId })) === null;
+  if (isNotExistedGroupId) {
+    return res.status(400).send({ message: "[NotExistedGroupId] Error occured" });
   }
 
-  const { groupName, keyword, ownerUid } = req.body;
-  let groupId = req.body.groupId;
+  const isDuplicatedKeyword = await groupModel
+    .findOne({ _id: req.body.groupId })
+    .populate("keywordIdList", "keyword")
+    .exec()
+    .then((query) => {
+      return query.keywordIdList.some((doc) => doc.keyword === req.body.keyword);
+    })
+    .catch(() => {
+      return res.status(400).send({ message: "[InvalidGroupId] Error occured" });
+    });
+
+  if (isDuplicatedKeyword) {
+    return res.status(400).send({ message: "[ExistedKeyword] Error occured" });
+  }
+
+  const { groupId, ownerUid, keyword } = req.body;
 
   try {
     const keywordResult = await keywordModel.create({ keyword, ownerUid });
     const { _id: keywordIdCreated } = keywordResult;
 
-    if (isEmptyString(groupId)) {
-      const { _id } = await groupModel.create({
-        name: groupName,
-        ownerUid,
-        keywordIdList: [keywordIdCreated],
-      });
+    const groupResult = await groupModel.findByIdAndUpdate(
+      { _id: groupId },
+      { $push: { keywordIdList: keywordIdCreated } },
+      { new: true }
+    );
 
-      groupId = _id;
-    } else {
-      await groupModel.findByIdAndUpdate(
-        { _id: groupId },
-        { $push: { keywordIdList: keywordIdCreated } }
-      );
-    }
-
-    await getKeywordPostList(keyword, keywordIdCreated);
-
-    const groupResult = await groupModel
-      .findOne({ _id: groupId })
-      .populate("keywordIdList", "keyword");
     return res.status(201).json(groupResult);
   } catch {
     return res

--- a/routes/groupRoute.js
+++ b/routes/groupRoute.js
@@ -2,6 +2,7 @@ const express = require("express");
 const router = express.Router();
 const groupController = require("../controllers/groupController");
 
+router.post("/", groupController.create);
 router.put("/:groupId", groupController.edit);
 
 module.exports = router;


### PR DESCRIPTION
## 이슈

- close #73 


## 상세 설명

- 기존의 그룹 및 키워드를 함께 생성하는 로직을 각각 생성하는 로직으로 분리했습니다.
- 키워드 생성 API 내에서 크롤링하는 로직은 삭제했습니다.
- 두 API 모두 해당 그룹의 정보를 응답으로 전달합니다.

## 참고사항
- 기존의 생성 로직은 키워드만 생성하는 로직으로 수정했습니다.
- 그룹 생성 로직은 신규 구현하였습니다.


## PR 체크 사항

- [x] conflict를 모두 해결하였습니다.
- [x] 가장 최신 dev 브랜치를 pull 하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] `console.log`나 주석 여부를 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!
- [x] `API 명세서`를 확인하였으며 동기화 하였습니다.

## 리뷰 반영사항

-
