### PR TITLE
Fix: 키워드 대시보드 내의 날짜 관련 이슈 수정

### DIFF
--- a/services/crawling.js
+++ b/services/crawling.js
@@ -1,8 +1,9 @@
-const { isToday } = require("../utils/date");
 const { POST_COUNT, NAVER_BLOG_HOST_NAME } = require("../config/constants");
 const postController = require("../controllers/postController");
-const { sanitizeHtmlEntity } = require("../utils/sanitizeHtmlEntity");
+const keywordModel = require("../models/keywordModel");
+const { isToday } = require("../utils/date");
 const { fetchHandler } = require("../utils/fetchHandler");
+const { sanitizeHtmlEntity } = require("../utils/sanitizeHtmlEntity");
 
 require("dotenv").config();
 
@@ -90,6 +91,10 @@ const getKeywordPostList = async (keyword, keywordId) => {
           postController.upsert({ keywordId, ...post.value });
         }
       }
+
+      await keywordModel
+        .findByIdAndUpdate(keywordId, { updatedAt: new Date() }, { timestamps: false })
+        .exec();
 
       const postDateOfLastPost = data.items[data.items?.length - 1]?.postdate;
       if (!isToday(postDateOfLastPost)) {

--- a/utils/date.js
+++ b/utils/date.js
@@ -109,7 +109,7 @@ const getCursorPeriod = (cursorIdDate, period, addPeriod = 0) => {
       } else {
         startDate.setDate(startDate.getDate() + 1);
 
-        endDate.setDate(startDate.getDate() + 6);
+        endDate.setDate(endDate.getDate() + 7);
         endDate.setMonth(endDate.getMonth() + 1);
         endDate.setDate(0);
         if (endDate.getDay() < 6) {

--- a/utils/date.js
+++ b/utils/date.js
@@ -69,16 +69,16 @@ const getCursorWeek = (cursorIdDate, addDay = 0) => {
   return [startDate, endDate];
 };
 
-const getCursorPeriod = (cursorIdDate, period, addPeriod = 0) => {
+const getCursorPeriod = (cursorIdDate, period) => {
   let startDate = new Date(cursorIdDate);
   let endDate = new Date(cursorIdDate);
   let periodLength = 0;
 
   switch (period) {
     case PERIOD.WEEKLY:
-      startDate.setDate(startDate.getDate() + 1 + addPeriod);
+      startDate.setDate(startDate.getDate() + 1);
 
-      endDate.setDate(endDate.getDate() + 7 + addPeriod);
+      endDate.setDate(endDate.getDate() + 7);
       endDate.setHours(23, 59, 59, 999);
       endDate = new Date(endDate);
 
@@ -89,7 +89,7 @@ const getCursorPeriod = (cursorIdDate, period, addPeriod = 0) => {
     case PERIOD.MONTHLY_DAILY:
       startDate.setDate(startDate.getDate() + 1);
 
-      endDate.setMonth(startDate.getMonth() + addPeriod + 1);
+      endDate.setMonth(startDate.getMonth() + 1);
       endDate.setDate(0);
       endDate.setHours(23, 59, 59, 999);
       endDate = new Date(endDate);
@@ -99,24 +99,14 @@ const getCursorPeriod = (cursorIdDate, period, addPeriod = 0) => {
       break;
 
     case PERIOD.MONTHLY_WEEKLY:
-      if (addPeriod !== 0) {
-        startDate.setDate(startDate.getDate() + (6 - startDate.getDay()));
-        startDate.setMonth(startDate.getMonth() + addPeriod);
-        startDate.setDate(1);
-        if (startDate.getDay() > 0) {
-          startDate.setDate(-startDate.getDay());
-        }
-      } else {
-        startDate.setDate(startDate.getDate() + 1);
+      startDate.setDate(startDate.getDate() + 1);
 
-        endDate.setDate(endDate.getDate() + 7);
-        endDate.setMonth(endDate.getMonth() + 1);
-        endDate.setDate(0);
-        if (endDate.getDay() < 6) {
-          endDate.setDate(endDate.getDate() + (6 - endDate.getDay()));
-        }
+      endDate.setDate(endDate.getDate() + 7);
+      endDate.setMonth(endDate.getMonth() + 1);
+      endDate.setDate(0);
+      if (endDate.getDay() < 6) {
+        endDate.setDate(endDate.getDate() + (6 - endDate.getDay()));
       }
-
       endDate.setHours(23, 59, 59, 999);
       endDate = new Date(endDate);
 


### PR DESCRIPTION
## 이슈

- close #75 


## 상세 설명

이슈 (1): '오늘의 게시물 분석하기' 버튼을 통해 당일 게시물을 크롤링한 후에도 키워드의 마지막 업데이트 일자가 변경되지 않는 이슈를 수정했습니다.
이슈 (2): 월간(주) 버튼 클릭 시 날짜가 NaN으로 표시되고, 차트가 보여지지 않는 이슈를 수정했습니다.


## 이슈 수정 화면
- **이슈 (1) 수정 전 화면**
![스크린샷 2024-12-28 오후 5 59 35](https://github.com/user-attachments/assets/b7d9a14c-3b3a-4147-af88-72ba0dbd76eb)

- **이슈 (1) 수정 후 화면**
![스크린샷 2024-12-28 오후 6 16 19](https://github.com/user-attachments/assets/27b496c1-94e2-4011-a8e0-0086068af61b)

- **이슈 (2) 수정 전 화면**
<img width="800" alt="스크린샷 2024-12-28 오후 5 59 14" src="https://github.com/user-attachments/assets/8cfab026-2cf5-438e-8ecd-0f1c24ef010a" />

- **이슈 (2) 수정 후 화면**
<img width="800" alt="스크린샷 2024-12-28 오후 6 16 37" src="https://github.com/user-attachments/assets/6fcec9f7-f817-44aa-8d75-b9228b6e7fb9" />


## 참고사항

- 월간(주)의 페이지네이션 기능 정상적으로 동작하는 것 확인했습니다.

## PR 체크 사항

- [x] conflict를 모두 해결하였습니다.
- [x] 가장 최신 dev 브랜치를 pull 하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] `console.log`나 주석 여부를 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!
- [x] `API 명세서`를 확인하였으며 동기화 하였습니다.

## 리뷰 반영사항

-
