### PR TITLE
Fix: 샘플 데이터 추가하는 로직 및 키워드 정보 조회에서 게시물 ID 목록 조회하는 로직 삭제

### DIFF
--- a/config/constants.js
+++ b/config/constants.js
@@ -7,7 +7,6 @@ const PERIOD = Object.freeze({
   MONTHLY_DAILY: "monthlyDaily",
   MONTHLY_WEEKLY: "monthlyWeekly",
 });
-const SAMPLE_GROUP_ID = "676bacaa98cdcd850d3b9c78";
 
 module.exports = {
   POST_COUNT,
@@ -15,5 +14,4 @@ module.exports = {
   DAY_OF_WEEK,
   MONTH,
   PERIOD,
-  SAMPLE_GROUP_ID,
 };

--- a/controllers/keywordsController.js
+++ b/controllers/keywordsController.js
@@ -1,6 +1,5 @@
 const { isValidString, isEmptyString } = require("../utils/validation");
 const keywordModel = require("../models/keywordModel");
-const postModel = require("../models/postModel");
 const { getKeywordPostList } = require("../services/crawling");
 
 const list = async (req, res) => {
@@ -12,10 +11,7 @@ const list = async (req, res) => {
     const { keywordId } = req.params;
     const keywordResult = await keywordModel.findById(keywordId).exec();
 
-    const postList = await postModel.find({ keywordId }).exec();
-    const postIdList = postList.length === 0 ? [] : postList.map((data) => data._id);
-
-    res.status(200).json({ ...keywordResult.toObject(), postId: postIdList });
+    res.status(200).json({ ...keywordResult.toObject() });
   } catch {
     return res
       .status(500)

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -1,7 +1,3 @@
-const { SAMPLE_GROUP_ID } = require("../config/constants");
-const groupModel = require("../models/groupModel");
-const keywordModel = require("../models/keywordModel");
-const postModel = require("../models/postModel");
 const userModel = require("../models/userModel");
 const { isValidString, isEmptyString } = require("../utils/validation");
 
@@ -22,7 +18,6 @@ const create = async (req, res) => {
   const { uid, email, displayName, photoURL } = req.body;
 
   try {
-    const isUnregisteredUser = (await userModel.exists({ uid }).exec()) === null;
     const userResult = await userModel
       .findOneAndUpdate(
         { uid },
@@ -36,71 +31,6 @@ const create = async (req, res) => {
         { upsert: true, new: true }
       )
       .exec();
-
-    if (isUnregisteredUser) {
-      const sampleGroup = await groupModel.findById(SAMPLE_GROUP_ID).exec();
-
-      if (sampleGroup.keywordIdList.length > 0) {
-        const newKeywordIdList = [];
-
-        for await (const sampleKeywordId of sampleGroup.keywordIdList) {
-          const sampleKeyword = await keywordModel.findById(sampleKeywordId).exec();
-          const samplePostList = await postModel
-            .find({ keywordId: sampleKeywordId })
-            .sort({ createdAt: 1 })
-            .exec();
-
-          const [newKeyword] = await keywordModel.create(
-            [
-              {
-                keyword: sampleKeyword.keyword,
-                ownerUid: userResult.uid,
-                createdAt: sampleKeyword.createdAt,
-                updatedAt: new Date(),
-              },
-            ],
-            { timestamps: false }
-          );
-
-          if (samplePostList.length > 0) {
-            for await (const samplePost of samplePostList) {
-              await postModel.create(
-                [
-                  {
-                    keywordId: newKeyword._id,
-                    title: samplePost.title,
-                    link: samplePost.link,
-                    content: samplePost.content,
-                    description: samplePost.description,
-                    commentCount: samplePost.commentCount,
-                    likeCount: samplePost.likeCount,
-                    isAd: samplePost.isAd,
-                    createdAt: samplePost.createdAt,
-                    updatedAt: new Date(),
-                  },
-                ],
-                { timestamps: false }
-              );
-            }
-          }
-
-          newKeywordIdList.push(newKeyword._id);
-        }
-
-        await groupModel.create(
-          [
-            {
-              ownerUid: userResult.uid,
-              name: sampleGroup.name,
-              keywordIdList: newKeywordIdList,
-              createdAt: sampleGroup.createdAt,
-              updatedAt: new Date(),
-            },
-          ],
-          { timestamps: false }
-        );
-      }
-    }
 
     return res.status(201).json({ userResult });
   } catch {


### PR DESCRIPTION
## 이슈

- close #78 
- close #79 


## 상세 설명

- 신규 사용자의 서비스 이해도를 높이기 위해 샘플 데이터를 추가해주는 기존 로직을 아래의 사유로 삭제했습니다.
  - 샘플 데이터를 신규 사용자에게 추가해주는 로직이 소요 시간이 길어 (최소 5초 ~ 최대 1분 30초 소요),  로그인이 이루어지지 않는 것처럼 보이는 이슈를 해결하기 위해
  - 로그인을 하지 않고도 서비스를 이용해볼 수 있도록 샘플 데이터 대시보드를 추가할 예정으로 해당 로직 불필요함
- 키워드 대시보드 진입 시에 키워드 정보를 조회하는 API 내에 게시물 ID 목록을 조회하는 로직에서 오랜 시간이 걸려 해당 로직을 삭제했습니다.

## 참고사항
- 키워드 정보 조회 API 응답 내에 게시물 ID 목록을 사용하는 로직이 없기 때문에, 클라이언트 서버에서 따로 처리해야 하는 로직은 없습니다.


## PR 체크 사항

- [x] conflict를 모두 해결하였습니다.
- [x] 가장 최신 dev 브랜치를 pull 하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] `console.log`나 주석 여부를 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!
- [x] `API 명세서`를 확인하였으며 동기화 하였습니다.

## 리뷰 반영사항

-
