### PR TITLE
Refactor: 최근 추가된 게시물이 있는 그룹 정보 요약 로직 성능 개선

### DIFF
--- a/config/constants.js
+++ b/config/constants.js
@@ -7,7 +7,6 @@ const PERIOD = Object.freeze({
   MONTHLY_DAILY: "monthlyDaily",
   MONTHLY_WEEKLY: "monthlyWeekly",
 });
-const SAMPLE_GROUP_ID = "676bacaa98cdcd850d3b9c78";
 
 module.exports = {
   POST_COUNT,
@@ -15,5 +14,4 @@ module.exports = {
   DAY_OF_WEEK,
   MONTH,
   PERIOD,
-  SAMPLE_GROUP_ID,
 };

--- a/controllers/groupController.js
+++ b/controllers/groupController.js
@@ -1,6 +1,26 @@
 const groupModel = require("../models/groupModel");
 const { isValidString, isEmptyString } = require("../utils/validation");
 
+const list = async (req, res) => {
+  if (!isValidString(req.params.groupId) || isEmptyString(req.params.groupId)) {
+    return res.status(400).send({ message: "[InvalidGroupId] Error occured" });
+  }
+
+  const groupId = req.params.groupId;
+
+  try {
+    const groupResult = await groupModel
+      .findById(groupId)
+      .populate("keywordIdList", "keyword")
+      .sort({ updatedAt: -1 });
+    return res.status(200).json(groupResult);
+  } catch {
+    return res
+      .status(500)
+      .send({ message: "[ServerError] Error occured in 'groupController.list'" });
+  }
+};
+
 const create = async (req, res) => {
   if (!isValidString(req.body.groupName) || isEmptyString(req.body.groupName)) {
     return res.status(400).send({ message: "[InvalidGroupName] Error occured" });
@@ -65,4 +85,4 @@ const edit = async (req, res) => {
   }
 };
 
-module.exports = { create, edit };
+module.exports = { list, create, edit };

--- a/controllers/groupsController.js
+++ b/controllers/groupsController.js
@@ -31,8 +31,8 @@ const summary = async (req, res) => {
     const uid = req.params.uid;
 
     let lastUpdatedGroup = { name: null };
-    let lastUpdatedkeyword = { updatedAt: null };
     let postUpdateNewest = [];
+    let lastUpdatedAt = null;
 
     const userKeywordList = await keywordModel
       .find({ ownerUid: uid }, { keyword: 1, updatedAt: 1 })
@@ -50,7 +50,8 @@ const summary = async (req, res) => {
         }
       }
 
-      const lastUpdatedAt = lastUpdatedkeyword.updatedAt.toString();
+      lastUpdatedAt = lastUpdatedkeyword.updatedAt;
+
       const lastUpdatedAtStart = new Date(lastUpdatedAt).setHours(0, 0, 0, 0);
       const lastUpdatedAtEnd = new Date(lastUpdatedAt).setHours(23, 59, 59, 999);
 
@@ -102,7 +103,7 @@ const summary = async (req, res) => {
     res.status(200).json({
       group: lastUpdatedGroup.name,
       postUpdateNewest,
-      lastUpdatedAt: lastUpdatedkeyword.updatedAt,
+      lastUpdatedAt,
     });
   } catch {
     return res

--- a/controllers/groupsController.js
+++ b/controllers/groupsController.js
@@ -31,7 +31,7 @@ const summary = async (req, res) => {
     const uid = req.params.uid;
 
     let lastUpdatedGroup = { name: null };
-    let postUpdateNewest = [];
+    let lastUpdatedPost = [];
     let lastUpdatedAt = null;
 
     const userKeywordList = await keywordModel
@@ -90,8 +90,8 @@ const summary = async (req, res) => {
         });
       }
 
-      postUpdateNewest = [...postCountByKeyword];
-      postUpdateNewest.forEach((update) => {
+      lastUpdatedPost = [...postCountByKeyword];
+      lastUpdatedPost.forEach((update) => {
         userKeywordList.forEach((keyword) => {
           if (update._id === keyword.id.toString()) {
             update.name = keyword.keyword;
@@ -102,7 +102,7 @@ const summary = async (req, res) => {
 
     res.status(200).json({
       group: lastUpdatedGroup.name,
-      postUpdateNewest,
+      postUpdateNewest: lastUpdatedPost,
       lastUpdatedAt,
     });
   } catch {

--- a/controllers/keywordsController.js
+++ b/controllers/keywordsController.js
@@ -1,6 +1,5 @@
 const { isValidString, isEmptyString } = require("../utils/validation");
 const keywordModel = require("../models/keywordModel");
-const postModel = require("../models/postModel");
 const { getKeywordPostList } = require("../services/crawling");
 
 const list = async (req, res) => {
@@ -12,10 +11,7 @@ const list = async (req, res) => {
     const { keywordId } = req.params;
     const keywordResult = await keywordModel.findById(keywordId).exec();
 
-    const postList = await postModel.find({ keywordId }).exec();
-    const postIdList = postList.length === 0 ? [] : postList.map((data) => data._id);
-
-    res.status(200).json({ ...keywordResult.toObject(), postId: postIdList });
+    res.status(200).json({ ...keywordResult.toObject() });
   } catch {
     return res
       .status(500)

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -1,7 +1,3 @@
-const { SAMPLE_GROUP_ID } = require("../config/constants");
-const groupModel = require("../models/groupModel");
-const keywordModel = require("../models/keywordModel");
-const postModel = require("../models/postModel");
 const userModel = require("../models/userModel");
 const { isValidString, isEmptyString } = require("../utils/validation");
 
@@ -22,7 +18,6 @@ const create = async (req, res) => {
   const { uid, email, displayName, photoURL } = req.body;
 
   try {
-    const isUnregisteredUser = (await userModel.exists({ uid }).exec()) === null;
     const userResult = await userModel
       .findOneAndUpdate(
         { uid },
@@ -36,71 +31,6 @@ const create = async (req, res) => {
         { upsert: true, new: true }
       )
       .exec();
-
-    if (isUnregisteredUser) {
-      const sampleGroup = await groupModel.findById(SAMPLE_GROUP_ID).exec();
-
-      if (sampleGroup.keywordIdList.length > 0) {
-        const newKeywordIdList = [];
-
-        for await (const sampleKeywordId of sampleGroup.keywordIdList) {
-          const sampleKeyword = await keywordModel.findById(sampleKeywordId).exec();
-          const samplePostList = await postModel
-            .find({ keywordId: sampleKeywordId })
-            .sort({ createdAt: 1 })
-            .exec();
-
-          const [newKeyword] = await keywordModel.create(
-            [
-              {
-                keyword: sampleKeyword.keyword,
-                ownerUid: userResult.uid,
-                createdAt: sampleKeyword.createdAt,
-                updatedAt: new Date(),
-              },
-            ],
-            { timestamps: false }
-          );
-
-          if (samplePostList.length > 0) {
-            for await (const samplePost of samplePostList) {
-              await postModel.create(
-                [
-                  {
-                    keywordId: newKeyword._id,
-                    title: samplePost.title,
-                    link: samplePost.link,
-                    content: samplePost.content,
-                    description: samplePost.description,
-                    commentCount: samplePost.commentCount,
-                    likeCount: samplePost.likeCount,
-                    isAd: samplePost.isAd,
-                    createdAt: samplePost.createdAt,
-                    updatedAt: new Date(),
-                  },
-                ],
-                { timestamps: false }
-              );
-            }
-          }
-
-          newKeywordIdList.push(newKeyword._id);
-        }
-
-        await groupModel.create(
-          [
-            {
-              ownerUid: userResult.uid,
-              name: sampleGroup.name,
-              keywordIdList: newKeywordIdList,
-              createdAt: sampleGroup.createdAt,
-              updatedAt: new Date(),
-            },
-          ],
-          { timestamps: false }
-        );
-      }
-    }
 
     return res.status(201).json({ userResult });
   } catch {

--- a/routes/groupRoute.js
+++ b/routes/groupRoute.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const groupController = require("../controllers/groupController");
 
 router.post("/", groupController.create);
+router.get("/:groupId", groupController.list);
 router.put("/:groupId", groupController.edit);
 
 module.exports = router;


### PR DESCRIPTION
## 이슈

- close #83

## 상세 설명

- 그룹 요약 연산 로직을 개선하여 응답 처리 속도를 단축했습니다. (테스트 결과 `as-is` 약 20s 소요 -> `to-be` 약 221ms 소요)
- 일반 사용자 데이터와 함께, 추후 구현될 샘플 대시보드에서도 동일하게 적용 가능합니다.
- 접속, 네트워크 환경에 따라 응답 처리 속도에 차이가 있습니다.

## 참고사항

- 주요 개선 내용은 키워드별 게시물 수 추출 로직 부분입니다.
   - 대상 키워드로 전체 게시물을 순회하는 작업을 반복하여 소요시간이 길었습니다. (기존 코드 아래 첨부)
   - 해당 목록을 비동기로 순회하던 부분을 mongoDB aggregate 으로 개선했습니다.
https://github.com/Team-Bloblow/Bloblow-Server/blob/50e70ff26e9f500f29a219a17b2967e07e59730d/controllers/groupsController.js#L66-L81
- 별도 설치한 라이브러리는 없습니다.

## PR 체크 사항

- [ ] conflict를 모두 해결하였습니다.
- [ ] 가장 최신 dev 브랜치를 pull 하였습니다.
- [ ] 코드 컨벤션을 모두 확인하였습니다.
- [ ] `console.log`나 주석 여부를 확인하였습니다.
- [ ] 브랜치명을 확인하였습니다.
- [ ] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!
- [ ] `API 명세서`를 확인하였으며 동기화 하였습니다.

## 리뷰 반영사항

-
