### PR TITLE
Feat: 크롤링 제한 시간 검사 로직 구현

### DIFF
--- a/models/keywordModel.js
+++ b/models/keywordModel.js
@@ -17,6 +17,9 @@ const keywordSchema = new Schema(
     excludedKeyword: {
       type: String,
     },
+    lastCrawledAt: {
+      type: Date,
+    },
   },
   {
     timestamps: true,


### PR DESCRIPTION
## 이슈

- close #87 

## 상세 설명

- 키워드 크롤링 요청 후 1시간 이내 재클릭시 크롤링이 진행되지 않도록 제한했습니다.
- 기존 키워드 DB 스키마에 `lastCrawledAt` 필드를 추가했습니다.
   - 크롤링 완료 후 해당 필드는 업데이트 되고, 추후 해당 시각을 기준으로 크롤링 가능여부를 검사합니다.

## 참고사항

- 제한시간 내 크롤링 재요청시 HTTP 상태 코드는 400을 반환합니다.
   - 에러 메시지는 `"[DuplicatedCrawlingRequest] Error occured"`를 반환합니다.
- 별도 설치한 라이브러리는 없습니다.

## PR 체크 사항

- [ ] conflict를 모두 해결하였습니다.
- [ ] 가장 최신 dev 브랜치를 pull 하였습니다.
- [ ] 코드 컨벤션을 모두 확인하였습니다.
- [ ] `console.log`나 주석 여부를 확인하였습니다.
- [ ] 브랜치명을 확인하였습니다.
- [ ] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!
- [ ] `API 명세서`를 확인하였으며 동기화 하였습니다.

## 리뷰 반영사항

-
